### PR TITLE
Make ysver:version a sub-type of rev:revision-label.

### DIFF
--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -979,11 +979,11 @@ Internet-Draft                 YANG Semver                  October 2021
       */
 
      typedef version {
-       type string {
+       type rev:revision-label {
          pattern '[0-9]+[.][0-9]+[.][0-9]+(_(non_)?compatible)?(-[A-Za-z0-9.-]+)?([+][A-Za-z0-9.-]+)?';
        }
        description
-         "Represents a YANG semantic version number.  The rules governing the
+         "Represents a YANG semantic version.  The rules governing the
           use of this revision label scheme are defined in the reference for
           this typedef.";
        reference

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -229,12 +229,14 @@
 <section anchor="semver_for_submodules" numbered="true" toc="default">
 <name>YANG Semver with submodules</name>
 <t>YANG Semver MAY be used to version submodules.  Submodule version are separate of any version on the including module, but if a submodule has changed, then the version of the including module MUST also be updated.</t>
-<t>The rules for determining the version change of a submodule are the same as those defined in <xref target="version_pattern" format="default"/> and <xref target="versioning_scheme" format="default"/> as applied to YANG modules, except they only apply to the part of the module schema defined within the submodule's file.</t>
+<t>The rules for determining the version change of a submodule are the same as those defined in <xref target="version_pattern" format="default"/>
+ and <xref target="versioning_scheme" format="default"/>
+ as applied to YANG modules, except they only apply to the part of the module schema defined within the submodule's file.</t>
 <t>One interesting case is moving definitions from one submodule to another in a way that does not change the resultant schema of the including module.  In this case:</t>
 <ol spacing="normal" type="1">
-  <li>The including module has editorial changes</li>
-  <li>The submodule with the schema definition removed has non-backwards-compatible changes</li>
-  <li>The submodule with the schema definitions added has backwards-compatible changes</li>
+<li>The including module has editorial changes</li>
+<li>The submodule with the schema definition removed has non-backwards-compatible changes</li>
+<li>The submodule with the schema definitions added has backwards-compatible changes</li>
 </ol>
 <t>Note that the meaning of a submodule may change drastically despite having no changes in content or revision due to changes in other submodules belonging to the same module (e.g. groupings and typedefs declared in one submodule and used in another).</t>
 </section>
@@ -319,13 +321,13 @@ SHOULD be used instead.</li>
       version number:
 </t>
 <ol spacing="normal" type="%i">
-  <li>"X.Y.Z" - the artifact version SHOULD be updated to "X.Y+1.0",
+<li>"X.Y.Z" - the artifact version SHOULD be updated to "X.Y+1.0",
     unless that version has already been used for this artifact but with different content,
     when the artifact version SHOULD be updated to
 	"X.Y.Z+1_compatible"" instead.</li>
-  <li>"X.Y.Z_compatible" - the artifact version SHOULD be updated to
+<li>"X.Y.Z_compatible" - the artifact version SHOULD be updated to
 	"X.Y.Z+1_compatible".</li>
-  <li>"X.Y.Z_non_compatible" - the artifact version SHOULD be updated to
+<li>"X.Y.Z_non_compatible" - the artifact version SHOULD be updated to
 	"X.Y.Z+1_non_compatible".</li>
 </ol>
 </li>
@@ -335,10 +337,10 @@ SHOULD be used instead.</li>
       number:
 </t>
 <ol spacing="normal" type="%i">
-  <li>"X.Y.Z" - the artifact version SHOULD be updated to "X.Y.Z+1"</li>
-  <li>"X.Y.Z_compatible" - the artifact version SHOULD be updated to
+<li>"X.Y.Z" - the artifact version SHOULD be updated to "X.Y.Z+1"</li>
+<li>"X.Y.Z_compatible" - the artifact version SHOULD be updated to
 	"X.Y.Z+1_compatible".</li>
-  <li>"X.Y.Z_non_compatible" - the artifact version SHOULD be updated to
+<li>"X.Y.Z_non_compatible" - the artifact version SHOULD be updated to
 	"X.Y.Z+1_non_compatible".</li>
 </ol>
 </li>
@@ -685,11 +687,11 @@ module ietf-yang-semver {
    */
 
   typedef version {
-    type string {
+    type rev:revision-label {
       pattern '[0-9]+[.][0-9]+[.][0-9]+(_(non_)?compatible)?(-[A-Za-z0-9.-]+)?([+][A-Za-z0-9.-]+)?';
     }
     description
-      "Represents a YANG semantic version number.  The rules governing the
+      "Represents a YANG semantic version.  The rules governing the
        use of this revision label scheme are defined in the reference for
        this typedef.";
     reference

--- a/yang-semver/ietf-yang-semver.yang
+++ b/yang-semver/ietf-yang-semver.yang
@@ -1,88 +1,90 @@
 module ietf-yang-semver {
-    yang-version 1.1;
-    namespace "urn:ietf:params:xml:ns:yang:ietf-yang-semver";
-    prefix ysver;
-    rev:revision-label-scheme "yang-semver";
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-semver";
+  prefix ysver;
+  rev:revision-label-scheme "yang-semver";
 
-    import ietf-yang-revisions {
-        prefix rev;
-    }
+  import ietf-yang-revisions {
+    prefix rev;
+  }
 
-    organization
-      "IETF NETMOD (Network Modeling) Working Group";
-    contact
-      "WG Web:   <http://tools.ietf.org/wg/netmod/>
-       WG List:  <mailto:netmod@ietf.org>
-       
-       Author:   Joe Clarke
-                 <mailto:jclarke@cisco.com>
-       Author:   Benoit Claise
-                 <mailto:benoit.claise@huawei.com>
-       Author:   Reshad Rahman
-                 <mailto:reshad@yahoo.com>
-       Author:   Robert Wilton
-                 <mailto:rwilton@cisco.com>
-       Author:   Balazs Lengyel
-                 <mailto:balazs.lengyel@ericsson.com>
-       Author:   Jason Sterne
-                 <mailto:jason.sterne@nokia.com>";
+  organization
+    "IETF NETMOD (Network Modeling) Working Group";
+  contact
+    "WG Web:   <http://tools.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     Author:   Joe Clarke
+               <mailto:jclarke@cisco.com>
+     Author:   Benoit Claise
+               <mailto:benoit.claise@huawei.com>
+     Author:   Reshad Rahman
+               <mailto:reshad@yahoo.com>
+     Author:   Robert Wilton
+               <mailto:rwilton@cisco.com>
+     Author:   Balazs Lengyel
+               <mailto:balazs.lengyel@ericsson.com>
+     Author:   Jason Sterne
+               <mailto:jason.sterne@nokia.com>";
+  description
+    "This module provides type and grouping definitions for YANG
+     packages.
+
+     Copyright (c) 2021 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC XXXX; see
+     the RFC itself for full legal notices.";
+
+  // RFC Ed.: update the date below with the date of RFC publication
+  // and remove this note.
+  // RFC Ed.: replace XXXX with actual RFC number and remove this
+  // note.
+  // RFC Ed. update the rev:revision-label to "1.0.0".
+
+  revision 2021-10-20 {
+    rev:revision-label "1.0.0-draft-ietf-netmod-yang-semver-04";
     description
-      "This module provides type and grouping definitions for YANG
-       packages.
-       
-       Copyright (c) 2020 IETF Trust and the persons identified as
-       authors of the code.  All rights reserved.
-       
-       Redistribution and use in source and binary forms, with or
-       without modification, is permitted pursuant to, and subject
-       to the license terms contained in, the Simplified BSD License
-       set forth in Section 4.c of the IETF Trust's Legal Provisions
-       Relating to IETF Documents
-       (http://trustee.ietf.org/license-info).
-       
-       This version of this YANG module is part of RFC XXXX; see
-       the RFC itself for full legal notices.";
+      "Initial revision";
+    reference
+      "RFC XXXX: YANG Semantic Versioning.";
+  }
 
-    // RFC Ed.: update the date below with the date of RFC publication
-    // and remove this note.
-    // RFC Ed.: replace XXXX with actual RFC number and remove this
-    // note.
-    // RFC Ed. update the rev:revision-label to "1.0.0".
-    revision 2021-10-20 {
-        rev:revision-label "1.0.0-draft-ietf-netmod-yang-semver-04";
-        description
-          "Initial revision";
-        reference
-          "RFC XXXX: YANG Semantic Versioning.";
-    }
+  /*
+   * Identities
+   */
 
-    /*
-     * Identities
-     */
-    identity yang-semver {
-        base rev:revision-label-scheme-base;
-        description
-          "The revision-label scheme corresponds to the YANG Semver scheme
-           which is defined by the pattern in the 'version' typedef below.
-           The rules governing this revision-label scheme are defined in the
-           reference for this identity.";
-        reference
-          "RFC XXXX: YANG Semantic Versioning.";
-    }
+  identity yang-semver {
+    base rev:revision-label-scheme-base;
+    description
+      "The revision-label scheme corresponds to the YANG Semver scheme
+       which is defined by the pattern in the 'version' typedef below.
+       The rules governing this revision-label scheme are defined in the
+       reference for this identity.";
+    reference
+      "RFC XXXX: YANG Semantic Versioning.";
+  }
 
-    /*
-     * Typedefs
-     */
-    typedef version {
-        type string {
-            pattern
-              '[0-9]+[.][0-9]+[.][0-9]+(_(non_)?compatible)?(-[A-Za-z0-9.-]+)?([+][A-Za-z0-9.-]+)?';
-        }
-        description
-          "Represents a YANG semantic version number.  The rules governing the
-           use of this revision label scheme are defined in the reference for
-           this typedef.";
-        reference
-          "RFC XXXX: YANG Semantic Versioning.";
+  /*
+   * Typedefs
+   */
+
+  typedef version {
+    type rev:revision-label {
+      pattern '[0-9]+[.][0-9]+[.][0-9]+(_(non_)?compatible)?(-[A-Za-z0-9.-]+)?([+][A-Za-z0-9.-]+)?';
     }
+    description
+      "Represents a YANG semantic version.  The rules governing the
+       use of this revision label scheme are defined in the reference for
+       this typedef.";
+    reference
+      "RFC XXXX: YANG Semantic Versioning.";
+  }
 }


### PR DESCRIPTION
Also correct another use of "YANG semver number."