### PR TITLE
move per node tags

### DIFF
--- a/yang-module-versioning/draft-ietf-netmod-yang-module-versioning.txt
+++ b/yang-module-versioning/draft-ietf-netmod-yang-module-versioning.txt
@@ -6,13 +6,13 @@ Network Working Group                                     R. Wilton, Ed.
 Internet-Draft                                       Cisco Systems, Inc.
 Updates: 6020, 7950, 8407, 8525 (if approved)             R. Rahman, Ed.
 Intended status: Standards Track                                        
-Expires: 22 April 2023                                   B. Lengyel, Ed.
+Expires: 24 April 2023                                   B. Lengyel, Ed.
                                                                 Ericsson
                                                                J. Clarke
                                                      Cisco Systems, Inc.
                                                                J. Sterne
                                                                    Nokia
-                                                         19 October 2022
+                                                         21 October 2022
 
 
                  Updated YANG Module Revision Handling
@@ -45,7 +45,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 22 April 2023.
+   This Internet-Draft will expire on 24 April 2023.
 
 
 
@@ -53,7 +53,7 @@ Status of This Memo
 
 
 
-Wilton, et al.            Expires 22 April 2023                 [Page 1]
+Wilton, et al.            Expires 24 April 2023                 [Page 1]
 
 Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
@@ -80,54 +80,53 @@ Table of Contents
    3.  Refinements to YANG revision handling . . . . . . . . . . . .   5
      3.1.  Updating a YANG module with a new revision  . . . . . . .   6
        3.1.1.  Backwards-compatible rules  . . . . . . . . . . . . .   7
-       3.1.2.  Non-backwards-compatible changes  . . . . . . . . . .   8
+       3.1.2.  Non-backwards-compatible changes  . . . . . . . . . .   7
      3.2.  Non-backwards-compatible-revision extension statement . .   8
      3.3.  Removing revisions from the revision history  . . . . . .   8
      3.4.  Revision label  . . . . . . . . . . . . . . . . . . . . .  10
        3.4.1.  File names  . . . . . . . . . . . . . . . . . . . . .  10
        3.4.2.  Revision label scheme extension statement . . . . . .  11
      3.5.  Examples for updating the YANG module revision history  .  11
-     3.6.  Node compatibility extension statements . . . . . . . . .  14
-   4.  Import by derived revision  . . . . . . . . . . . . . . . . .  18
-     4.1.  Module import examples  . . . . . . . . . . . . . . . . .  19
-   5.  Updates to ietf-yang-library  . . . . . . . . . . . . . . . .  21
-     5.1.  Resolving ambiguous module imports  . . . . . . . . . . .  21
-     5.2.  YANG library versioning augmentations . . . . . . . . . .  21
-       5.2.1.  Advertising revision-label  . . . . . . . . . . . . .  22
+   4.  Import by derived revision  . . . . . . . . . . . . . . . . .  14
+     4.1.  Module import examples  . . . . . . . . . . . . . . . . .  16
+   5.  Updates to ietf-yang-library  . . . . . . . . . . . . . . . .  17
+     5.1.  Resolving ambiguous module imports  . . . . . . . . . . .  17
+     5.2.  YANG library versioning augmentations . . . . . . . . . .  18
+       5.2.1.  Advertising revision-label  . . . . . . . . . . . . .  18
        5.2.2.  Reporting how deprecated and obsolete nodes are
-               handled . . . . . . . . . . . . . . . . . . . . . . .  22
-   6.  Versioning of YANG instance data  . . . . . . . . . . . . . .  23
-   7.  Guidelines for using the YANG module update rules . . . . . .  23
-     7.1.  Guidelines for YANG module authors  . . . . . . . . . . .  23
+               handled . . . . . . . . . . . . . . . . . . . . . . .  18
+   6.  Versioning of YANG instance data  . . . . . . . . . . . . . .  19
+   7.  Guidelines for using the YANG module update rules . . . . . .  19
+     7.1.  Guidelines for YANG module authors  . . . . . . . . . . .  20
        7.1.1.  Making non-backwards-compatible changes to a YANG
-               module  . . . . . . . . . . . . . . . . . . . . . . .  24
-     7.2.  Versioning Considerations for Clients . . . . . . . . . .  25
-   8.  Module Versioning Extension YANG Modules  . . . . . . . . . .  26
-   9.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  38
-   10. Security Considerations . . . . . . . . . . . . . . . . . . .  39
-   11. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  39
+               module  . . . . . . . . . . . . . . . . . . . . . . .  21
+     7.2.  Versioning Considerations for Clients . . . . . . . . . .  22
+   8.  Module Versioning Extension YANG Modules  . . . . . . . . . .  22
+   9.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  31
+   10. Security Considerations . . . . . . . . . . . . . . . . . . .  32
+   11. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  32
+     11.1.  YANG Module Registrations  . . . . . . . . . . . . . . .  32
 
 
 
-Wilton, et al.            Expires 22 April 2023                 [Page 2]
+Wilton, et al.            Expires 24 April 2023                 [Page 2]
 
 Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
 
-     11.1.  YANG Module Registrations  . . . . . . . . . . . . . . .  39
      11.2.  Guidance for versioning in IANA maintained YANG
-            modules  . . . . . . . . . . . . . . . . . . . . . . . .  40
-   12. References  . . . . . . . . . . . . . . . . . . . . . . . . .  41
-     12.1.  Normative References . . . . . . . . . . . . . . . . . .  41
-     12.2.  Informative References . . . . . . . . . . . . . . . . .  42
-   Appendix A.  Examples of changes that are NBC . . . . . . . . . .  44
-   Appendix B.  Examples of applying the NBC change guidelines . . .  44
-     B.1.  Removing a data node  . . . . . . . . . . . . . . . . . .  45
-     B.2.  Changing the type of a leaf node  . . . . . . . . . . . .  45
-     B.3.  Reducing the range of a leaf node . . . . . . . . . . . .  46
-     B.4.  Changing the key of a list  . . . . . . . . . . . . . . .  46
-     B.5.  Renaming a node . . . . . . . . . . . . . . . . . . . . .  47
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  48
+            modules  . . . . . . . . . . . . . . . . . . . . . . . .  33
+   12. References  . . . . . . . . . . . . . . . . . . . . . . . . .  34
+     12.1.  Normative References . . . . . . . . . . . . . . . . . .  35
+     12.2.  Informative References . . . . . . . . . . . . . . . . .  35
+   Appendix A.  Examples of changes that are NBC . . . . . . . . . .  37
+   Appendix B.  Examples of applying the NBC change guidelines . . .  38
+     B.1.  Removing a data node  . . . . . . . . . . . . . . . . . .  38
+     B.2.  Changing the type of a leaf node  . . . . . . . . . . . .  38
+     B.3.  Reducing the range of a leaf node . . . . . . . . . . . .  39
+     B.4.  Changing the key of a list  . . . . . . . . . . . . . . .  40
+     B.5.  Renaming a node . . . . . . . . . . . . . . . . . . . . .  40
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  41
 
 1.  Introduction
 
@@ -165,22 +164,18 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
 
 
-Wilton, et al.            Expires 22 April 2023                 [Page 3]
+
+Wilton, et al.            Expires 24 April 2023                 [Page 3]
 
 Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
 
-   The document comprises six parts:
+   The document comprises five parts:
 
    *  Refinements to the YANG 1.1 module revision update procedure,
       supported by new extension statements to indicate when a revision
       contains non-backwards-compatible changes, and an optional
       revision label.
-
-   *  YANG extension statements are defined to allow annotation of
-      individual schema nodes with information to clarify the
-      compatibility of changes to those nodes in specific revisions of
-      the module.
 
    *  A YANG extension statement allowing YANG module imports to specify
       an earliest module revision that may satisfy the import
@@ -218,17 +213,18 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
    Section 5.1 defines how a client of a YANG library datastore schema
    resolves ambiguous imports for modules which are not "import-only".
 
-
-
-
-Wilton, et al.            Expires 22 April 2023                 [Page 4]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
    This document updates [RFC8407] section 4.7.  Section 7 provides
    guidelines on managing the lifecycle of YANG modules that may contain
    non-backwards-compatible changes and a branched revision history.
+
+
+
+
+
+Wilton, et al.            Expires 24 April 2023                 [Page 4]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
 
    This document updates [RFC8525] with augmentations to include
    revision labels in the YANG library data and two boolean leafs to
@@ -262,11 +258,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
       change between two YANG module revisions, as defined in
       Section 3.1.2
 
-   *  Node compatibility statement: An extension statements (e.g. nbc-
-      change-at) that can be used to indicate the backwards
-      compatibility of individual schema nodes and specific YANG
-      statements.
-
 3.  Refinements to YANG revision handling
 
    [RFC7950] and [RFC6020] assume, but do not explicitly state, that the
@@ -275,13 +266,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
    module or submodule that are both directly derived from the same
    parent revision.
 
-
-
-Wilton, et al.            Expires 22 April 2023                 [Page 5]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
    This document clarifies [RFC7950] and [RFC6020] to explicitly allow
    non-linear development of YANG module and submodule revisions, so
    that they MAY have multiple revisions that directly derive from the
@@ -289,6 +273,14 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
    and submodule revisions continue to be uniquely identified by their
    revision date, and hence all revisions of a given module or submodule
    MUST have unique revision dates.
+
+
+
+
+Wilton, et al.            Expires 24 April 2023                 [Page 5]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
 
    A corollary to the above is that the relationship between two module
    or submodule revisions cannot be determined by comparing the module
@@ -329,20 +321,22 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
    Where pragmatic, updates to YANG modules SHOULD be backwards-
    compatible, following the definition in Section 3.1.1.
 
-
-
-
-
-Wilton, et al.            Expires 22 April 2023                 [Page 6]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
    A new module revision MAY contain NBC changes, e.g., the semantics of
    an existing data-node definition MAY be changed in an NBC manner
    without requiring a new data-node definition with a new identifier.
    A YANG extension, defined in Section 3.2, is used to signal the
    potential for incompatibility to existing module users and readers.
+
+
+
+
+
+
+
+Wilton, et al.            Expires 24 April 2023                 [Page 6]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
 
    As per [RFC7950] and [RFC6020], all published revisions of a module
    are given a new unique revision date.  This applies even for module
@@ -386,19 +380,19 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
       not change the semantic meaning of the module are backwards-
       compatible.
 
-
-
-
-Wilton, et al.            Expires 22 April 2023                 [Page 7]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
 3.1.2.  Non-backwards-compatible changes
 
    Any changes to YANG modules that are not defined by Section 3.1.1 as
    being backwards-compatible are classified as "non-backwards-
    compatible" changes.
+
+
+
+
+Wilton, et al.            Expires 24 April 2023                 [Page 7]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
 
 3.2.  Non-backwards-compatible-revision extension statement
 
@@ -442,15 +436,19 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
    The author MUST NOT remove the first (i.e., newest) revision entry in
    the revision history.
 
+   Example revision history:
 
 
 
-Wilton, et al.            Expires 22 April 2023                 [Page 8]
+
+
+
+
+
+Wilton, et al.            Expires 24 April 2023                 [Page 8]
 
 Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
-
-   Example revision history:
 
    revision 2020-11-11 {
      rev:revision-label 4.0.0;
@@ -501,7 +499,9 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
 
 
-Wilton, et al.            Expires 22 April 2023                 [Page 9]
+
+
+Wilton, et al.            Expires 24 April 2023                 [Page 9]
 
 Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
@@ -557,7 +557,7 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
 
 
-Wilton, et al.            Expires 22 April 2023                [Page 10]
+Wilton, et al.            Expires 24 April 2023                [Page 10]
 
 Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
@@ -613,7 +613,7 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
 
 
-Wilton, et al.            Expires 22 April 2023                [Page 11]
+Wilton, et al.            Expires 24 April 2023                [Page 11]
 
 Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
@@ -669,7 +669,7 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
 
 
-Wilton, et al.            Expires 22 April 2023                [Page 12]
+Wilton, et al.            Expires 24 April 2023                [Page 12]
 
 Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
@@ -725,7 +725,7 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
 
 
-Wilton, et al.            Expires 22 April 2023                [Page 13]
+Wilton, et al.            Expires 24 April 2023                [Page 13]
 
 Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
@@ -766,217 +766,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
          //YANG module definition starts here
        }
 
-3.6.  Node compatibility extension statements
-
-   In addition to the revision extension statement in Section 3.2, YANG
-   extension statements are also available to indicate compatibility
-   information for schema nodes and certain individual YANG statements.
-
-   The node compatibility extension statements are applicable to schema
-   nodes (e.g. leaf, rpc, choice) as defined in [RFC7950], as well as a
-   set of YANG statements (e.g. typedef) as listed in the YANG
-   definition of the nbc-change-at extension in the ietf-yang-revisions
-   module in this document.
-
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 14]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
-   While the top level non-backwards-compatible-revision statement is
-   mandatory when there is a non-backwards-compatible change, the node
-   compatibility statements are optional.
-
-   For many YANG statements, programmatic tooling can determine whether
-   the changes to a statement between two module revisions constitutes a
-   backwards-compatible or non-backwards-compatible change.  However,
-   for some statements, it may be impractical for tooling to determine
-   whether the changes are backwards-compatible or not.  For example, in
-   the general case, tooling cannot determine whether the change in a
-   YANG description statement causes a change in the semantics of a YANG
-   schema node.  If the change is to fix a typo or spelling mistake then
-   the change can be classified as an editorial backwards-compatible
-   change.  Conversely, if the change modifies the behavioral
-   specification of the data node then the change would need to be
-   classified as either a non editorial backwards-compatible change or a
-   non-backwards- compatible change.  Hence, extension statements are
-   defined to annotate a YANG module with additional information to
-   clarify the scope of changes in cases that cannot be determined by
-   algorithmic comparison.
-
-   Three extensions are defined for schema node compatibility
-   information:
-
-   nbc-change-at:  Indicates a specific YANG statement had a non-
-      backwards-compatible change at a particular module or sub-module
-      revision
-
-   bc-change-at:  Indicates a specific YANG statement had a backwards-
-      compatible change at a particular module or sub-module revision
-
-   editorial-change-at:  Indicates a specific YANG statement had an
-      editorial change at a particular module or sub-module revision.
-      The meaning of an editorial change is as per YANG Semver
-      [I-D.ietf-netmod-yang-semver]
-
-   When a node compatibility statement is added to a schema node in a
-   sub-module, the revision indicated for the compatibility statement is
-   that of the sub-module.
-
-   Adding, modifying or removing any of the node compatibility
-   statements is considered to be a BC change.
-
-   The following example illustrates the node compatibility statements:
-
-
-
-
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 15]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
-             container some-stuff {
-               leaf used-to-be-a-string {
-                 rev:nbc-change-at "3.0.0" {
-                   description "Changed from a string to a uint32.";
-                 }
-                 type uint32;
-               }
-               leaf fixed-my-description-typo {
-                 rev:editorial-change-at "2022-06-03";
-                 type string;
-                 description "This description used to have a typo."
-               }
-               list sir-changed-a-lot {
-                 rev:editorial-change-at "3.0.0";
-                 rev:bc-change-at "2.3.0";
-                 rev:bc-change-at "1.2.1_non_compatible";
-                 description "a list of stuff";
-                 ordered-by user;
-                 key "foo";
-                 leaf foo {
-                   type string;
-                 }
-                 leaf thing {
-                   type uint8;
-                 }
-               }
-
-   Note that an individual YANG statement may have a backwards-
-   compatible change in a revision that is non-backwards-compatible
-   (e.g. some other node changed in a non-backwards-compatible fashion
-   in that particular revision).
-
-   If changes are ported from one branch of YANG model revisions to
-   another branch, care must be taken with any node compatibilty
-   statements.  A simple copy-n-paste should not be used.  The node
-   compatibilty statements may incorrectly reference a revision that is
-   not in the history of the new revision.  Further, the statements
-   might not apply depending on what the history is like in that new
-   branch (e.g., an NBC change that is ported might not be an NBC change
-   in the new branch).  Node compatiblity statements should not be
-   copied over to the new branch.  Instead, the changes should be
-   considered as completely new on the new branch, and any compatibility
-   information should be generated from scratch.
-
-
-
-
-
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 16]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
-   When a node compatibility statement is present, that compatibilty
-   statement is the authoritative classification of the backwards
-   compatibility of the change to the schema node in the specifed
-   revision.  This allows a human author to explicitly communicate the
-   compatibilty and potentially override the rules specified in this
-   document.  This is useful in a number of situations including:
-
-   *  When a tool may not be able to accurately determine the
-      compatibilty of a change.  For example, a change in a 'pattern' or
-      'must' statement can be difficult for a user or tool to determine
-      if it is a compatible change.
-
-   *  When a pattern, range or other statement is changed to more
-      correctly define the server constraint.  An example is correcting
-      a pattern that incorrectly included 355.xxx.xxx.xxx as a possible
-      IPv4 address to make it only accept up to 255.xxx.xxx.xxx.
-
-   Nothing about the backwards compatibility of a schema node is implied
-   by the absence of a node compatibility statement.  Hence, the schema
-   node definition must be compared between the two revisions to
-   determine the backwards compatibility.
-
-   If any nbc-change-at extension statements exists in a module or sub-
-   module, then the module or sub-module MUST have non-backwards-
-   compatible-revision substatements in each revision statement of the
-   module or sub-module history where the revision matches the argument
-   of any nbc-change-at statements.  If any revision statements are
-   removed, then all node compatibiilty statements that reference that
-   revision MUST also be removed.  Conversely, node compatibilty
-   statements MUST NOT be removed unless the associated revision
-   statement in the revision history is removed.
-
-   If a node compatiblity statement is added to a grouping, then all
-   instances where the grouping is used in the module or by an importing
-   module are also impacted by the compatibilty information.  Similarly
-   for a 'typedef', all leafs and list-lists that use that typedef share
-   the specified compatibility classification.  A non-backwards-
-   compatible change to a typedef or grouping defined in one module that
-   is used by an importing module, does not cause the importing module
-   to add a non-backwards-compatible-revision statement to the revision
-   history.  Non-backwards-compatible marking does not carry through
-   import statements.
-
-   A node compatibility statement at a leaf, leaf-list or typedef
-   context takes precedence over a node compatibility statement in a
-   typedef used by the leaf, leaf-list or typedef.  If multiple typedefs
-   with compatibility statements are used by a leaf, leaf-list or
-   typedef (e.g. a union), and there is no compatibility statement at
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 17]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
-   the top leaf, leaf-list or typedef context, then the order of
-   precedence used to classify the compatibility of the top level leaf,
-   leaf-list or typedef is as follows: nbc-change-at, bc-change-at and
-   finally editorial-change-at.  That is, the leaf, leaf-list or typedef
-   takes the most impactful change classification of all the underlying
-   typedefs.
-
-   Node compatibility statements are not supported on YANG statements
-   such as 'pattern' or 'range'.  The compatibility statement instead
-   goes against the leaf, leaf-list or typedef context.
-
-   Node compatibility statements that refer to pre-release revisions of
-   a module MUST be removed when a full release revision of the module
-   is published.
-
-   Node compatibilty statements SHOULD NOT be used when it isn't clear
-   which change the statement is referring to.  For example: If a leaf
-   is reordered within a container, a node compatibility statement
-   SHOULD NOT be used against the parent container nor against the
-   reordered leaf.  Similarly, if a leaf is renamed or moved to another
-   context without keeping the old leaf present in the model and marked
-   obsolete, a node compatibilty statement SHOULD not be used.
-
 4.  Import by derived revision
 
    [RFC7950] and [RFC6020] allow YANG module "import" statements to
@@ -987,6 +776,15 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
    alternative choice of using an import statement without any revision
    date statement is also not ideal because the importing module may not
    work with all possible revisions of the imported module.
+
+
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 14]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
 
    Instead, it is desirable for an importing module to specify a
    "minimum required revision" of a module that it is compatible with,
@@ -1002,13 +800,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
    The ietf-revisions module defines the "revision-or-derived" extension
    statement, a substatement to the YANG "import" statement, to allow
    for a "minimum required revision" to be specified during import:
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 18]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
 
       The argument to the "revision-or-derived" extension statement is a
       revision date or a revision label.
@@ -1038,6 +829,19 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
       Adding, modifying or removing a "revision-or-derived" extension
       statement is considered to be a BC change.
 
+
+
+
+
+
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 15]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
+
 4.1.  Module import examples
 
    Consider the example module "example-module" from Section 3.5 that is
@@ -1059,13 +863,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
                 |
             2019-06-01                 <- 3.1.0
 
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 19]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
 4.1.1.  Example 1
 
    This example selects module revisions that match, or are derived from
@@ -1085,6 +882,21 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
    import example-module {
      rev:revision-or-derived 2.0.0;
    }
+
+
+
+
+
+
+
+
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 16]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
 
 4.1.2.  Example 2
 
@@ -1110,18 +922,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
      rev:revision-or-derived 2019-06-01;
    }
 
-
-
-
-
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 20]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
 5.  Updates to ietf-yang-library
 
    This document updates YANG 1.1 [RFC7950] and YANG library [RFC8525]
@@ -1146,6 +946,14 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
    The following two rules remove the ambiguity:
 
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 17]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
+
    If a module import statement could resolve to more than one module
    revision defined in the datastore schema, and one of those revisions
    is implemented (i.e., not an "import-only" module), then the import
@@ -1162,20 +970,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
    The "ietf-yang-library-revisions" YANG module has the following
    structure (using the notation defined in [RFC8340]):
-
-
-
-
-
-
-
-
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 21]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
 
    module: ietf-yang-library-revisions
@@ -1207,6 +1001,15 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
    are:
 
    deprecated-nodes-implemented:  If set to "true", this leaf indicates
+
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 18]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
+
       that all schema nodes with a status "deprecated" are implemented
       equivalently as if they had status "current"; otherwise deviations
       MUST be used to explicitly remove "deprecated" nodes from the
@@ -1220,19 +1023,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
    Servers SHOULD set both the "deprecated-nodes-implemented" and
    "obsolete-nodes-absent" leafs to "true".
-
-
-
-
-
-
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 22]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
 
    If a server does not set the "deprecated-nodes-implemented" leaf to
    "true", then clients MUST NOT rely solely on the "rev:non-backwards-
@@ -1264,6 +1054,18 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
    The following text updates section 4.7 of [RFC8407] to revise the
    guidelines for updating YANG modules.
 
+
+
+
+
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 19]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
+
 7.1.  Guidelines for YANG module authors
 
    All IETF YANG modules MUST include revision-label statements for all
@@ -1281,14 +1083,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
    A "rev:non-backwards-compatible-revision" statement MUST be added if
    there are NBC changes relative to the previous revision.
-
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 23]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
 
    Removing old revision statements from a module's revision history
    could break import by revision, and hence it is RECOMMENDED to retain
@@ -1319,6 +1113,15 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
       compatibility impact for clients and users of the module or
       submodule
 
+
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 20]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
+
 7.1.1.  Making non-backwards-compatible changes to a YANG module
 
    There are various valid situations where a YANG module has to be
@@ -1338,13 +1141,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
        risk of breaking modules which import the modified module, and
        the removed identifier may be accidently reused in a future
        revision.
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 24]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
 
    2.  For deprecated data nodes the "description" statement SHOULD also
        indicate until when support for the node is guaranteed (if
@@ -1375,6 +1171,13 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
        of removing a node, that node SHOULD first be deprecated and then
        obsoleted.
 
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 21]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
+
    See Appendix B for examples on how NBC changes can be made.
 
 7.2.  Versioning Considerations for Clients
@@ -1392,15 +1195,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
       the specific changes between module revision.  In particular,
       clients SHOULD NOT migrate to NBC revisions of a module without
       understanding any potential impact of the specific NBC changes.
-
-
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 25]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
 
    *  Clients SHOULD plan to make changes to match published status
       changes.  When a node's status changes from "current" to
@@ -1433,6 +1227,13 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
        "WG Web:   <https://datatracker.ietf.org/wg/netmod/>
        WG List:  <mailto:netmod@ietf.org>
 
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 22]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
+
        Author:   Joe Clarke
                  <mailto:jclarke@cisco.com>
 
@@ -1450,13 +1251,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
      description
        "This YANG 1.1 module contains definitions and extensions to
        support updated YANG revision handling.
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 26]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
 
        Copyright (c) 2021 IETF Trust and the persons identified as
        authors of the code.  All rights reserved.
@@ -1488,6 +1282,14 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
          "Initial version.";
        reference
          "XXXX: Updated YANG Module Revision Handling";
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 23]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
+
      }
 
      typedef revision-label {
@@ -1506,14 +1308,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
          revision-date.";
        reference
          "XXXX: Updated YANG Module Revision Handling;
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 27]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
          Section 3.3, Revision label";
      }
 
@@ -1544,6 +1338,14 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
          Conversely, if a revision does not contain a
          'non-backwards-compatible' statement then all changes,
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 24]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
+
          relative to the preceding revision in the revision history,
          MUST be backwards-compatible.
 
@@ -1562,13 +1364,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
          "XXXX: Updated YANG Module Revision Handling;
          Section 3.2, non-backwards-compatible revision extension statement";
      }
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 28]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
 
      extension revision-label {
        argument revision-label;
@@ -1600,6 +1395,13 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
          Section 3.3, Revision label";
      }
 
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 25]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
+
      extension revision-label-scheme {
        argument revision-label-scheme-base;
        description
@@ -1618,14 +1420,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
          Adding a revision label scheme is a backwards-compatible version
          change.  Changing a revision label scheme is a
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 29]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
          non-backwards-compatible version change, unless the new revision
          label scheme is backwards-compatible with the replaced revision
          label scheme.  Removing a revision label scheme is a
@@ -1656,6 +1450,14 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
          is an acceptable revision for import.
 
          An 'import' statement MUST NOT contain both a
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 26]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
+
          'revision-or-derived' extension statement and a
          'revision-date' statement.
 
@@ -1674,14 +1476,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
          statement to an import is a backwards-compatible change.
          ";
 
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 30]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
        reference
          "XXXX: Updated YANG Module Revision Handling;
          Section 4, Import by derived revision";
@@ -1698,163 +1492,7 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
      }
 
-     extension nbc-change-at {
-       argument revision-date-or-label;
-       description
-         "A node compatibility statement that identifies a revision
-         (by revision-label, or revision date if a revision-label is
-         not available) where a non-backwards-compatible change has
-         occurred in a particular YANG statement relative to the
-         previous revision listed in the revision history.
 
-         The format of the revision-label argument MUST conform to the
-         pattern defined for the ietf-yang-revisions
-         revision-date-or-label typedef.
-
-         The following YANG statements MAY have zero or more
-         nbc-change-at substatements:
-           - all schema node statements (leaf, rpc, choice, etc)
-           - 'feature' statements
-           - 'grouping' statements
-           - 'identity' statements
-           - 'must' statements
-           - 'refine' statements
-           - 'typedef' statements
-           - YANG extensions
-
-         Each YANG statement MUST only a have a single node
-         compatibilty statement (one of nbc-change-at, bc-change-at
-         or editorial-change-at) for a particular revision. When a node
-         has more than one of the node compatibilty statements (for
-         different revisions), they must be ordered from most recent
-         to least recent.
-
-         An nbc-change-at statement can have 0 or 1 'description'
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 31]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
-         substatements.
-
-         The nbc-change-at statement in not inherited by descendants
-         in the schema tree. It only applies to the specific YANG
-         statement with which it is associated.
-         ";
-
-       reference
-         "XXXX: Updated YANG Module Revision Handling;
-         Section 3.6, Node compatibility extension statements";
-
-     }
-
-     extension bc-change-at {
-       argument revision-date-or-label;
-       description
-         "A node compatibility statement that identifies a revision
-         (by revision-label, or revision date if a revision-label is
-         not available) where a backwards-compatible change has
-         occurred in a particular YANG statement relative to the
-         previous revision listed in the revision history.
-
-         The format of the revision-label argument MUST conform to the
-         pattern defined for the ietf-yang-revisions
-         revision-date-or-label typedef.
-
-         The following YANG statements MAY have zero or more
-         bc-change-at substatements:
-           - all schema node statements (leaf, rpc, choice, etc)
-           - 'feature' statements
-           - 'grouping' statements
-           - 'identity' statements
-           - 'must' statements
-           - 'refine' statements
-           - 'typedef' statements
-           - YANG extensions
-
-         Each YANG statement MUST only a have a single node
-         compatibilty statement (one of nbc-change-at, bc-change-at
-         or editorial-change-at) for a particular revision. When a node
-         has more than one of the node compatibilty statements (for
-         different revisions), they must be ordered from most recent
-         to least recent.
-
-         An bc-change-at statement can have 0 or 1 'description'
-         substatements.
-
-         The bc-change-at statement in not inherited by descendants
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 32]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
-         in the schema tree. It only applies to the specific YANG
-         statement with which it is associated.
-         ";
-
-       reference
-         "XXXX: Updated YANG Module Revision Handling;
-         Section 3.6, Node compatibility extension statements";
-
-     }
-
-     extension editorial-change-at {
-       argument revision-date-or-label;
-       description
-         "A node compatibility statement that identifies a revision
-         (by revision-label, or revision date if a revision-label is
-         not available) where an editorial change has
-         occurred in a particular YANG statement relative to the
-         previous revision listed in the revision history.
-
-         The format of the revision-label argument MUST conform to the
-         pattern defined for the ietf-yang-revisions
-         revision-date-or-label typedef.
-
-         The following YANG statements MAY have zero or more
-         editorial-change-at substatements:
-           - all schema node statements (leaf, rpc, choice, etc)
-           - 'feature' statements
-           - 'grouping' statements
-           - 'identity' statements
-           - 'must' statements
-           - 'refine' statements
-           - 'typedef' statements
-           - YANG extensions
-
-         Each YANG statement MUST only a have a single node
-         compatibilty statement (one of nbc-change-at, bc-change-at
-         or editorial-change-at) for a particular revision. When a node
-         has more than one of the node compatibilty statements (for
-         different revisions), they must be ordered from most recent
-         to least recent.
-
-         An editorial-change-at statement can have 0 or 1 'description'
-         substatements.
-
-         The editorial-change-at statement in not inherited by descendants
-         in the schema tree. It only applies to the specific YANG
-         statement with which it is associated.
-         ";
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 33]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
-       reference
-         "XXXX: Updated YANG Module Revision Handling;
-         Section 3.6, Node compatibility extension statements";
-
-     }
 
 
    }
@@ -1868,6 +1506,13 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
      namespace
        "urn:ietf:params:xml:ns:yang:ietf-yang-library-revisions";
      prefix yl-rev;
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 27]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
 
      import ietf-yang-revisions {
        prefix rev;
@@ -1898,14 +1543,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
         Author:   Balazs Lengyel
                   <mailto:balazs.lengyel@ericsson.com>
 
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 34]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
         Author:   Jason Sterne
                   <mailto:jason.sterne@nokia.com>";
      description
@@ -1925,6 +1562,13 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
         This version of this YANG module is part of RFC XXXX; see
         the RFC itself for full legal notices.
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 28]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
 
         The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
         NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
@@ -1954,14 +1598,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
        leaf revision-label {
          type rev:revision-label;
          description
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 35]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
            "The revision label associated with this module revision.
             The label MUST match the rev:revision-label value in the specific
             revision of the module loaded in this module-set.";
@@ -1982,6 +1618,14 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
            "The revision label associated with this submodule revision.
             The label MUST match the rev:revision-label value in the specific
             revision of the submodule included by the module loaded in
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 29]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
+
             this module-set.";
 
          reference
@@ -2010,14 +1654,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
      augment "/yanglib:yang-library/yanglib:module-set/"
              + "yanglib:import-only-module/yanglib:submodule" {
        description
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 36]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
          "Add a revision label to submodule information";
        leaf revision-label {
          type rev:revision-label;
@@ -2038,6 +1674,13 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
          "Augmentations to the ietf-yang-library module to indicate how
           deprecated and obsoleted nodes are handled for each datastore
           schema supported by the server.";
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 30]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
 
        leaf deprecated-nodes-implemented {
          type boolean;
@@ -2066,14 +1709,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
            "XXXX: Updated YANG Module Revision Handling;
             Section 5.2.2, Reporting how deprecated and obsolete nodes
             are handled";
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 37]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
        }
      }
    }
@@ -2095,6 +1730,13 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
    *  Ebben Aries
 
    *  Jan Lindblad
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 31]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
 
    *  Jason Sterne
 
@@ -2122,14 +1764,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
    both Anees Shaikh and Rob Shakir for their input into this problem
    space.
 
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 38]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
    We would also like to thank Lou Berger, Andy Bierman, Martin
    Bjorklund, Italo Busi, Tom Hill, Scott Mansfield, Kent Watsen for
    their contributions and review comments.
@@ -2151,6 +1785,14 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
       URI: urn:ietf:params:xml:ns:yang:ietf-yang-revisions
       Registrant Contact: The IESG.
       XML: N/A, the requested URI is an XML namespace.
+
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 32]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
 
       URI: urn:ietf:params:xml:ns:yang:ietf-yang-library-revisions
       Registrant Contact: The IESG.
@@ -2179,13 +1821,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
       Prefix: yl-rev
 
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 39]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
       Reference: [RFCXXXX]
 
 11.2.  Guidance for versioning in IANA maintained YANG modules
@@ -2201,6 +1836,19 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
    [RoutingTypesYang] is derived from the "Address Family Numbers"
    [AddrFamilyReg] and "Subsequent Address Family Identifiers (SAFI)
    Parameters" [SAFIReg] IANA registries.
+
+
+
+
+
+
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 33]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
 
    Normally, updates to the registries cause any derived YANG modules to
    be updated in a backwards-compatible way, but there are some cases
@@ -2229,19 +1877,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
    removing an enum entry, changing the identifier of an enum entry, or
    changing the described meaning of an enum entry.
 
-
-
-
-
-
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 40]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
-
    Non-normative examples of updates to enumeration types in IANA
    maintained modules that would be classified as backwards-compatible
    changes are: Adding a new enum entry to the end of the enumeration,
@@ -2262,6 +1897,14 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
    that does not change its defined meaning.
 
 12.  References
+
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 34]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
 
 12.1.  Normative References
 
@@ -2286,17 +1929,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
    [RFC3688]  Mealling, M., "The IETF XML Registry", BCP 81, RFC 3688,
               DOI 10.17487/RFC3688, January 2004,
               <https://www.rfc-editor.org/info/rfc3688>.
-
-
-
-
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 41]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
 
    [RFC6020]  Bjorklund, M., Ed., "YANG - A Data Modeling Language for
               the Network Configuration Protocol (NETCONF)", RFC 6020,
@@ -2323,6 +1955,13 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
 
 12.2.  Informative References
 
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 35]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
+
    [AddrFamilyReg]
               "Address Family Numbers IANA Registry",
               <https://www.iana.org/assignments/address-family-numbers/
@@ -2341,18 +1980,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
               netmod-yang-instance-file-format-21, 8 October 2021,
               <https://www.ietf.org/archive/id/draft-ietf-netmod-yang-
               instance-file-format-21.txt>.
-
-
-
-
-
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 42]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
 
    [I-D.ietf-netmod-yang-packages]
               Wilton, R., Rahman, R., Clarke, J., Sterne, J., and B. Wu,
@@ -2381,6 +2008,16 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
               <https://www.ietf.org/archive/id/draft-ietf-netmod-yang-
               ver-selection-00.txt>.
 
+
+
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 36]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
+
    [I-D.ietf-netmod-yang-versioning-reqs]
               Clarke, J., "YANG Module Versioning Requirements", Work in
               Progress, Internet-Draft, draft-ietf-netmod-yang-
@@ -2401,14 +2038,6 @@ Internet-Draft    Updated YANG Module Revision Handling     October 2022
    [RFC8340]  Bjorklund, M. and L. Berger, Ed., "YANG Tree Diagrams",
               BCP 215, RFC 8340, DOI 10.17487/RFC8340, March 2018,
               <https://www.rfc-editor.org/info/rfc8340>.
-
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 43]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
 
    [RoutingTypesDecRevision]
               "2020-12-31 revision of iana-routing-types.yang",
@@ -2437,6 +2066,14 @@ Appendix A.  Examples of changes that are NBC
    *  Modifying the description in a way that changes the semantic
       meaning of the data node.
 
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 37]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
+
    *  Any changes that remove any previously allowed values from the
       allowed value set of the data node, either through changes in the
       type definition, or the addition or changes to "must" statements,
@@ -2454,17 +2091,6 @@ Appendix B.  Examples of applying the NBC change guidelines
    described in section Section 7.1.1.
 
    The examples are all for "config true" nodes.
-
-
-
-
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 44]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
 
    Alternatively, the NBC changes MAY be done non-incrementally and
    without using "status" statements if the server can support multiple
@@ -2495,6 +2121,15 @@ B.2.  Changing the type of a leaf node
        This is a BC change.  The description is updated to indicate that
        "vpn-name" is replacing this node.
 
+
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 38]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
+
    2.  A new schema node, e.g., "vpn-name", of type string is added to
        the same location as the existing node "vpn-id".  This new node
        has status "current" and its description explains that it is
@@ -2512,15 +2147,6 @@ B.2.  Changing the type of a leaf node
            "when" statement since this would be an NBC change, but the
            server could reject the old node from being set if the new
            node is already set.
-
-
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 45]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
 
        2.  If the new node is set and a client does a get or get-config
            operation on the old node, the server could map the value.
@@ -2552,6 +2178,14 @@ B.3.  Reducing the range of a leaf node
        be impacted, so a change of this nature should be done carefully,
        e.g., by using the steps described in Appendix B.2
 
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 39]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
+
 B.4.  Changing the key of a list
 
    Changing the key of a list has a big impact to the client.  For
@@ -2570,13 +2204,6 @@ B.4.  Changing the key of a list
        case the new list is called "sessions-address", has status
        "current" and its description should explain that it is replacing
        list "session".
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 46]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
 
    3.  During the period of time when both lists are supported, the
        interactions between the two lists is outside the scope of this
@@ -2607,6 +2234,14 @@ B.5.  Renaming a node
        year).  This is a BC change.  The description is updated to
        indicate the node that is replacing this node.
 
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 40]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
+
    2.  The new schema node "ip-address" is added to the same location as
        the existing node "ip-adress".  This new node has status
        "current" and its description should explain that it is replacing
@@ -2624,15 +2259,6 @@ B.5.  Renaming a node
            "when" statement since this would be an NBC change, but the
            server could reject the old node from being set if the new
            node is already set.
-
-
-
-
-
-Wilton, et al.            Expires 22 April 2023                [Page 47]
-
-Internet-Draft    Updated YANG Module Revision Handling     October 2022
-
 
        2.  If the new node is set and a client does a get or get-config
            operation on the old node, the server could use the value of
@@ -2665,6 +2291,13 @@ Authors' Addresses
    Email: jclarke@cisco.com
 
 
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 41]
+
+Internet-Draft    Updated YANG Module Revision Handling     October 2022
+
+
    Jason Sterne
    Nokia
    Email: jason.sterne@nokia.com
@@ -2685,4 +2318,35 @@ Authors' Addresses
 
 
 
-Wilton, et al.            Expires 22 April 2023                [Page 48]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wilton, et al.            Expires 24 April 2023                [Page 42]

--- a/yang-module-versioning/draft-ietf-netmod-yang-module-versioning.xml
+++ b/yang-module-versioning/draft-ietf-netmod-yang-module-versioning.xml
@@ -91,14 +91,10 @@
     <t>This document defines a flexible versioning solution. Several other documents build on this solution with additional capabilities. <xref target="I-D.ietf-netmod-yang-schema-comparison"/> specifies an algorithm that can be used to compare two revisions of a YANG schema and provide granular information to allow module users to determine if they are impacted by changes between the revisions. The <xref target="I-D.ietf-netmod-yang-semver"/> document extends the module versioning work by introducing a revision label scheme based on semantic versioning. YANG packages <xref target="I-D.ietf-netmod-yang-packages"/> provides a mechanism to group sets of related YANG modules together in order to manage schema and conformance of YANG modules as a cohesive set instead of individually. Finally, <xref target="I-D.ietf-netmod-yang-ver-selection"/> provides a schema selection mechanism that allows a client to choose which schemas to use when interacting with a server from the available schema that are supported and advertised by the server. These other documents are mentioned here as informative references. Support of the other documents is not required in an implementation in order to take advantage of the mechanisms and functionality offered by this module versioning document.
     </t>
 
-  <t>The document comprises six parts:
+  <t>The document comprises five parts:
   <list style="bullets">
     <t>Refinements to the YANG 1.1 module revision update procedure, supported by new extension statements to indicate
     when a revision contains non-backwards-compatible changes, and an optional revision label.</t>
-    <t>YANG extension statements are defined to allow annotation of individual
-    schema nodes with information to clarify the compatibility of changes
-    to those nodes in specific revisions of the module.
-    </t>
     <t>A YANG extension statement allowing YANG module imports to specify an earliest module revision that may satisfy the
     import dependency.</t>
     <t>Updates and augmentations to ietf-yang-library to include the revision label in the module and submodule descriptions, to
@@ -145,8 +141,6 @@
         in <xref target="bc_update_rules"/></t>
         <t>Non-backwards-compatible (NBC) change: A non-backwards-compatible change between two YANG module revisions, as
         defined in <xref target="nbc_update_rules"/></t>
-        <t>Node compatibility statement: An extension statements (e.g. nbc-change-at)
-        that can be used to indicate the backwards compatibility of individual schema nodes and specific YANG statements.</t>
         </list>
       </t>
     </section>
@@ -446,156 +440,6 @@ revision 2019-01-02 {
       </artwork>
     </figure>
   </section>
-  
-  <section anchor="node-tags" title="Node compatibility extension statements">
-    <t>In addition to the revision extension statement in <xref target="revision_nbc_marker"/>, YANG extension statements are also available to indicate compatibility information for schema nodes and certain individual YANG statements.
-    </t>
-    <t>The node compatibility extension statements are applicable to schema nodes
-    (e.g. leaf, rpc, choice) as defined in <xref target="RFC7950"/>, as well as
-    a set of YANG statements (e.g. typedef) as listed in the YANG definition of
-    the nbc-change-at extension in the ietf-yang-revisions module in this document.
-    </t>
-    <t>While the top level non-backwards-compatible-revision statement is mandatory when there
-    is a non-backwards-compatible change, the node compatibility statements are optional.
-    </t>
-    <t>For many YANG statements, programmatic tooling can determine whether
-    the changes to a statement between two module revisions constitutes a backwards-compatible
-    or non-backwards-compatible change.  However, for some statements, it
-    may be impractical for tooling to determine whether the changes
-    are backwards-compatible or not.  For example, in the general case,
-    tooling cannot determine whether the change in a YANG description
-    statement causes a change in the semantics of a YANG schema node.  If
-    the change is to fix a typo or spelling mistake then the change can
-    be classified as an editorial backwards-compatible change.
-    Conversely, if the change modifies the behavioral specification of
-    the data node then the change would need to be classified as either a
-    non editorial backwards-compatible change or a non-backwards-
-    compatible change.  Hence, extension statements are defined to
-    annotate a YANG module with additional information to clarify the
-    scope of changes in cases that cannot be determined by algorithmic
-    comparison.
-    </t>
-    <t>Three extensions are defined for schema node compatibility information:
-    <list style="hanging">
-        <t hangText="nbc-change-at:">Indicates a specific YANG statement
-        had a non-backwards-compatible change at a particular module
-        or sub-module revision</t>
-        <t hangText="bc-change-at:">Indicates a specific YANG statement
-        had a backwards-compatible change at a particular module or sub-module revision</t>
-        <t hangText="editorial-change-at:">Indicates a specific YANG statement
-        had an editorial change at a particular module or sub-module revision. 
-        The meaning of an editorial change is as per YANG Semver 
-        <xref target="I-D.ietf-netmod-yang-semver"/></t>
-    </list>
-    </t>
-    <t>When a node compatibility statement is added to a schema node in a sub-module,
-    the revision indicated for the compatibility statement is that of the sub-module.
-    </t>
-    <t>Adding, modifying or removing any of the node compatibility
-      statements is considered to be a BC change.
-    </t>
-    <t>The following example illustrates the node compatibility statements:
-      <figure>
-        <artwork>
-          container some-stuff {
-            leaf used-to-be-a-string {
-              rev:nbc-change-at "3.0.0" {
-                description "Changed from a string to a uint32.";
-              }
-              type uint32;
-            }
-            leaf fixed-my-description-typo {
-              rev:editorial-change-at "2022-06-03";
-              type string;
-              description "This description used to have a typo."
-            }
-            list sir-changed-a-lot {
-              rev:editorial-change-at "3.0.0";
-              rev:bc-change-at "2.3.0";
-              rev:bc-change-at "1.2.1_non_compatible";
-              description "a list of stuff";
-              ordered-by user;
-              key "foo";
-              leaf foo {
-                type string;
-              }
-              leaf thing {
-                type uint8;
-              }
-            }
-        </artwork>
-      </figure>
-    </t>
-    <t>Note that an individual YANG statement may have a backwards-compatible change
-    in a revision that is non-backwards-compatible (e.g. some other node changed
-    in a non-backwards-compatible fashion in that particular revision).
-    </t>
-    <t>If changes are ported from one branch of YANG model revisions to another
-    branch, care must be taken with any node compatibilty statements. 
-    A simple copy-n-paste should not be used. The node compatibilty statements 
-    may incorrectly reference a revision that is not in the history of the 
-    new revision. Further, the statements might not apply depending on what 
-    the history is like in that new branch (e.g., an NBC change
-    that is ported might not be an NBC change in the new branch).
-    Node compatiblity statements should not be copied over to the new 
-    branch. Instead, the changes should be 
-    considered as completely new on the new branch, and any compatibility information
-    should be generated from scratch.
-    </t>
-    <t>When a node compatibility  statement is present, that compatibilty
-    statement is the authoritative classification of the backwards compatibility
-    of the change to the schema node in the specifed revision. This allows a human
-    author to explicitly communicate the compatibilty and potentially override
-    the rules specified in this document. This is useful in a number of situations
-    including:
-    <list style="symbols">
-      <t>When a tool may not be able to accurately determine the compatibilty of a change. For example, a change in a 'pattern' or 'must' statement can be difficult for a user or tool to determine if it is a compatible change.</t>
-      <t>When a pattern, range or other statement is changed to more correctly define the server constraint. An example is correcting a pattern that incorrectly included 355.xxx.xxx.xxx as a possible IPv4 address to make it only accept up to 255.xxx.xxx.xxx.</t>
-    </list>
-    </t>	
-    <t>Nothing about the backwards compatibility of a schema node is implied by the absence of a node compatibility statement. Hence, the schema node definition must be compared between the two revisions to determine the backwards compatibility.
-    </t>
-    <t>If any nbc-change-at extension statements exists in a module or sub-module, then the module or sub-module MUST have non-backwards-compatible-revision
-    substatements in each revision statement of the module or sub-module history where the 
-    revision matches the argument of any nbc-change-at statements. If any revision statements are removed, then all node compatibiilty statements that reference that revision MUST also be removed. Conversely, node compatibilty statements MUST NOT be removed unless the
-    associated revision statement in the revision history is removed.
-    </t>
-    <t>If a node compatiblity statement is added to a grouping,
-    then all instances where the grouping is used in the module or
-    by an importing module are also impacted by the compatibilty information. 
-    Similarly for a 'typedef', all 
-    leafs and list-lists that use that typedef share the specified 
-    compatibility classification. A non-backwards-compatible change 
-    to a typedef or grouping defined in one module that is used by 
-    an importing module, does not cause the importing module to add a
-    non-backwards-compatible-revision statement to the revision history.
-    Non-backwards-compatible marking does not carry through import statements.
-    </t>
-    <t>A node compatibility statement at a leaf, leaf-list or typedef context
-    takes precedence over a node compatibility statement in a typedef
-    used by the leaf, leaf-list or typedef. If multiple typedefs with 
-    compatibility statements are used by a leaf, leaf-list or typedef (e.g. a union), and there 
-    is no compatibility statement at the top leaf, leaf-list or typedef context, then
-    the order of precedence used to classify the compatibility of the top level leaf, 
-    leaf-list or typedef is as follows: nbc-change-at, bc-change-at and finally 
-    editorial-change-at. That is, the leaf, leaf-list or typedef takes the most 
-    impactful change classification of all the underlying typedefs.</t>
-    <t>Node compatibility statements are not supported on YANG
-    statements such as 'pattern' or 'range'. The compatibility statement
-    instead goes against the leaf, leaf-list or typedef context.
-    </t>
-    <t>Node compatibility statements that refer to pre-release revisions of a module
-    MUST be removed when a full release revision of the module is published.
-    </t>
-    <t>Node compatibilty statements SHOULD NOT be used when it isn't clear which
-    change the statement is referring to. For example: If a leaf is reordered 
-    within a container, a node compatibility statement SHOULD NOT be used against
-    the parent container nor against the reordered leaf. Similarly, if a leaf
-    is renamed or moved to another context without keeping the old leaf present
-    in the model and marked obsolete, a node compatibilty statement SHOULD not
-    be used.
-    </t>       
-</section>
   
 </section>
 <section title="Import by derived revision" anchor="import">
@@ -1114,140 +958,7 @@ module ietf-yang-revisions {
 
   }
   
-  extension nbc-change-at {
-    argument revision-date-or-label;
-    description
-      "A node compatibility statement that identifies a revision 
-      (by revision-label, or revision date if a revision-label is
-      not available) where a non-backwards-compatible change has 
-      occurred in a particular YANG statement relative to the
-      previous revision listed in the revision history.
- 
-      The format of the revision-label argument MUST conform to the
-      pattern defined for the ietf-yang-revisions
-      revision-date-or-label typedef.
 
-      The following YANG statements MAY have zero or more 
-      nbc-change-at substatements:
-        - all schema node statements (leaf, rpc, choice, etc)
-        - 'feature' statements
-        - 'grouping' statements
-        - 'identity' statements
-        - 'must' statements
-        - 'refine' statements
-        - 'typedef' statements
-        - YANG extensions
-                          
-      Each YANG statement MUST only a have a single node
-      compatibilty statement (one of nbc-change-at, bc-change-at
-      or editorial-change-at) for a particular revision. When a node
-      has more than one of the node compatibilty statements (for 
-      different revisions), they must be ordered from most recent
-      to least recent.
-       
-      An nbc-change-at statement can have 0 or 1 'description' 
-      substatements.
-       
-      The nbc-change-at statement in not inherited by descendants
-      in the schema tree. It only applies to the specific YANG 
-      statement with which it is associated.   
-      ";
-       
-    reference
-      "XXXX: Updated YANG Module Revision Handling;
-      Section 3.6, Node compatibility extension statements";
-      
-  }
-
-  extension bc-change-at {
-    argument revision-date-or-label;
-    description
-      "A node compatibility statement that identifies a revision 
-      (by revision-label, or revision date if a revision-label is
-      not available) where a backwards-compatible change has 
-      occurred in a particular YANG statement relative to the
-      previous revision listed in the revision history.
- 
-      The format of the revision-label argument MUST conform to the
-      pattern defined for the ietf-yang-revisions
-      revision-date-or-label typedef.
-
-      The following YANG statements MAY have zero or more 
-      bc-change-at substatements:
-        - all schema node statements (leaf, rpc, choice, etc)
-        - 'feature' statements
-        - 'grouping' statements
-        - 'identity' statements
-        - 'must' statements
-        - 'refine' statements
-        - 'typedef' statements
-        - YANG extensions
-                          
-      Each YANG statement MUST only a have a single node
-      compatibilty statement (one of nbc-change-at, bc-change-at
-      or editorial-change-at) for a particular revision. When a node
-      has more than one of the node compatibilty statements (for 
-      different revisions), they must be ordered from most recent
-      to least recent.
-       
-      An bc-change-at statement can have 0 or 1 'description' 
-      substatements.
-       
-      The bc-change-at statement in not inherited by descendants
-      in the schema tree. It only applies to the specific YANG 
-      statement with which it is associated.   
-      ";
-       
-    reference
-      "XXXX: Updated YANG Module Revision Handling;
-      Section 3.6, Node compatibility extension statements";
-      
-  }
-
-  extension editorial-change-at {
-    argument revision-date-or-label;
-    description
-      "A node compatibility statement that identifies a revision 
-      (by revision-label, or revision date if a revision-label is
-      not available) where an editorial change has 
-      occurred in a particular YANG statement relative to the
-      previous revision listed in the revision history.
- 
-      The format of the revision-label argument MUST conform to the
-      pattern defined for the ietf-yang-revisions
-      revision-date-or-label typedef.
-
-      The following YANG statements MAY have zero or more 
-      editorial-change-at substatements:
-        - all schema node statements (leaf, rpc, choice, etc)
-        - 'feature' statements
-        - 'grouping' statements
-        - 'identity' statements
-        - 'must' statements
-        - 'refine' statements
-        - 'typedef' statements
-        - YANG extensions
-                          
-      Each YANG statement MUST only a have a single node
-      compatibilty statement (one of nbc-change-at, bc-change-at
-      or editorial-change-at) for a particular revision. When a node
-      has more than one of the node compatibilty statements (for 
-      different revisions), they must be ordered from most recent
-      to least recent.
-       
-      An editorial-change-at statement can have 0 or 1 'description' 
-      substatements.
-       
-      The editorial-change-at statement in not inherited by descendants
-      in the schema tree. It only applies to the specific YANG 
-      statement with which it is associated.   
-      ";
-       
-    reference
-      "XXXX: Updated YANG Module Revision Handling;
-      Section 3.6, Node compatibility extension statements";
-      
-  }
 
   
 }

--- a/yang-schema-comparison/draft-ietf-netmod-yang-schema-comparision.xml
+++ b/yang-schema-comparison/draft-ietf-netmod-yang-schema-comparision.xml
@@ -1,5 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
-<!DOCTYPE rfc SYSTEM "rfc2629-xhtml.ent">
+<!DOCTYPE rfc SYSTEM "rfc2629-xhtml.ent" [
+<!ENTITY RFC7950 SYSTEM "reference.RFC.7950.xml">
+]>
 <?xml-stylesheet type="text/xsl" href="rfc2629.xslt" ?>
 <?rfc toc="yes"?>
 <?rfc tocompact="yes"?>
@@ -11,7 +13,7 @@
 <?rfc inline="yes"?>
 <?rfc compact="yes"?>
 <?rfc subcompact="no"?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" category="std" consensus="true" ipr="trust200902" docName="draft-ietf-netmod-yang-schema-comparison-01" obsoletes="" updates="" submissionType="IETF" xml:lang="en" tocInclude="true" tocDepth="4" symRefs="true" sortRefs="true" version="3">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" category="std" consensus="true" ipr="trust200902" docName="draft-ietf-netmod-yang-schema-comparison-01" obsoletes="" updates="7950" submissionType="IETF" xml:lang="en" tocInclude="true" tocDepth="4" symRefs="true" sortRefs="true" version="3">
   <!-- xml2rfc v2v3 conversion 3.3.0 -->
   <front>
     <title abbrev="YANG Schema Comparison">YANG Schema Comparison</title>
@@ -97,7 +99,13 @@
    "OPTIONAL" in this document are to be interpreted as described in BCP 14
    <xref target="RFC2119" format="default"/> <xref target="RFC8174" format="default"/> when, and only when, they
    appear in all capitals, as shown here.</t>
-      <t>This document uses terminology introduced in the YANG versioning
+    <t>This document makes use of the following terminology introduced in
+      the YANG 1.1 Data Modeling Language <xref target="RFC7950"/>: <list
+          style="symbols">
+          <t>schema node</t>
+        </list>
+    </t>
+    <t>This document uses terminology introduced in the YANG versioning
    requirements document <xref target="I-D.ietf-netmod-yang-versioning-reqs" format="default"/>.</t>
       <t>This document makes of the following terminology introduced in the
    YANG Packages <xref target="I-D.ietf-netmod-yang-packages" format="default"/>:
@@ -110,6 +118,8 @@
       <ul spacing="normal">
         <li>Change scope: Whether a change between two revisions is classified as
         non-backwards-compatible, backwards-compatible, or editorial.</li>
+        <li>Node compatibility statement: An extension statements (e.g. nbc-change-at)
+        that can be used to indicate the backwards compatibility of individual schema nodes and specific YANG statements.</li>
       </ul>
     </section>
     <section anchor="generic_comparison_algorithm" numbered="true" toc="default">
@@ -159,6 +169,155 @@
       <section anchor="change_scope_statements" numbered="true" toc="default">
         <name>YANG module revision scope extension annotations</name>
         <t/>
+      </section>
+     <section anchor="node-tags" title="Node compatibility extension statements">
+        <t>In addition to the revision extension statement in (TBD: ref to Module Versionning), this document defines YANG extension statements to indicate compatibility information for individual schema nodes and certain YANG statements.
+        </t>
+        <t>The node compatibility extension statements are applicable to schema nodes
+        (e.g. leaf, rpc, choice) as defined in <xref target="RFC7950"/>, as well as
+        a set of YANG statements (e.g. typedef) as listed in the YANG definition of
+        the nbc-change-at extension in the ietf-yang-revisions module in this document.
+        </t>
+        <t>While the top level non-backwards-compatible-revision statement is mandatory when there
+        is a non-backwards-compatible change, the node compatibility statements are optional.
+        </t>
+        <t>For many YANG statements, programmatic tooling can determine whether
+        the changes to a statement between two module revisions constitutes a backwards-compatible
+        or non-backwards-compatible change.  However, for some statements, it
+        may be impractical for tooling to determine whether the changes
+        are backwards-compatible or not.  For example, in the general case,
+        tooling cannot determine whether the change in a YANG description
+        statement causes a change in the semantics of a YANG schema node.  If
+        the change is to fix a typo or spelling mistake then the change can
+        be classified as an editorial backwards-compatible change.
+        Conversely, if the change modifies the behavioral specification of
+        the data node then the change would need to be classified as either a
+        non editorial backwards-compatible change or a non-backwards-
+        compatible change.  Hence, extension statements are defined to
+        annotate a YANG module with additional information to clarify the
+        scope of changes in cases that cannot be determined by algorithmic
+        comparison.
+        </t>
+        <t>Three extensions are defined for schema node compatibility information:
+        <list style="hanging">
+            <t hangText="nbc-change-at:">Indicates a specific YANG statement
+            had a non-backwards-compatible change at a particular module
+            or sub-module revision</t>
+            <t hangText="bc-change-at:">Indicates a specific YANG statement
+            had a backwards-compatible change at a particular module or sub-module revision</t>
+            <t hangText="editorial-change-at:">Indicates a specific YANG statement
+            had an editorial change at a particular module or sub-module revision. 
+            The meaning of an editorial change is as per YANG Semver 
+            <xref target="I-D.ietf-netmod-yang-semver"/></t>
+        </list>
+        </t>
+        <t>When a node compatibility statement is added to a schema node in a sub-module,
+        the revision indicated for the compatibility statement is that of the sub-module.
+        </t>
+        <t>Adding, modifying or removing any of the node compatibility
+          statements is considered to be a BC change.
+        </t>
+        <t>The following example illustrates the node compatibility statements:
+          <figure>
+            <artwork>
+              container some-stuff {
+                leaf used-to-be-a-string {
+                  rev:nbc-change-at "3.0.0" {
+                    description "Changed from a string to a uint32.";
+                  }
+                  type uint32;
+                }
+                leaf fixed-my-description-typo {
+                  rev:editorial-change-at "2022-06-03";
+                  type string;
+                  description "This description used to have a typo."
+                }
+                list sir-changed-a-lot {
+                  rev:editorial-change-at "3.0.0";
+                  rev:bc-change-at "2.3.0";
+                  rev:bc-change-at "1.2.1_non_compatible";
+                  description "a list of stuff";
+                  ordered-by user;
+                  key "foo";
+                  leaf foo {
+                    type string;
+                  }
+                  leaf thing {
+                    type uint8;
+                  }
+                }
+            </artwork>
+          </figure>
+        </t>
+        <t>Note that an individual YANG statement may have a backwards-compatible change
+        in a revision that is non-backwards-compatible (e.g. some other node changed
+        in a non-backwards-compatible fashion in that particular revision).
+        </t>
+        <t>If changes are ported from one branch of YANG model revisions to another
+        branch, care must be taken with any node compatibilty statements. 
+        A simple copy-n-paste should not be used. The node compatibilty statements 
+        may incorrectly reference a revision that is not in the history of the 
+        new revision. Further, the statements might not apply depending on what 
+        the history is like in that new branch (e.g., an NBC change
+        that is ported might not be an NBC change in the new branch).
+        Node compatiblity statements should not be copied over to the new 
+        branch. Instead, the changes should be 
+        considered as completely new on the new branch, and any compatibility information
+        should be generated from scratch.
+        </t>
+        <t>When a node compatibility  statement is present, that compatibilty
+        statement is the authoritative classification of the backwards compatibility
+        of the change to the schema node in the specifed revision. This allows a human
+        author to explicitly communicate the compatibilty and potentially override
+        the rules specified in this document. This is useful in a number of situations
+        including:
+        <list style="symbols">
+          <t>When a tool may not be able to accurately determine the compatibilty of a change. For example, a change in a 'pattern' or 'must' statement can be difficult for a user or tool to determine if it is a compatible change.</t>
+          <t>When a pattern, range or other statement is changed to more correctly define the server constraint. An example is correcting a pattern that incorrectly included 355.xxx.xxx.xxx as a possible IPv4 address to make it only accept up to 255.xxx.xxx.xxx.</t>
+        </list>
+        </t>    
+        <t>Nothing about the backwards compatibility of a schema node is implied by the absence of a node compatibility statement. Hence, the schema node definition must be compared between the two revisions to determine the backwards compatibility.
+        </t>
+        <t>If any nbc-change-at extension statements exists in a module or sub-module, then the module or sub-module MUST have non-backwards-compatible-revision
+        substatements in each revision statement of the module or sub-module history where the 
+        revision matches the argument of any nbc-change-at statements. If any revision statements are removed, then all node compatibiilty statements that reference that revision MUST also be removed. Conversely, node compatibilty statements MUST NOT be removed unless the
+        associated revision statement in the revision history is removed.
+        </t>
+        <t>If a node compatiblity statement is added to a grouping,
+        then all instances where the grouping is used in the module or
+        by an importing module are also impacted by the compatibilty information. 
+        Similarly for a 'typedef', all 
+        leafs and list-lists that use that typedef share the specified 
+        compatibility classification. A non-backwards-compatible change 
+        to a typedef or grouping defined in one module that is used by 
+        an importing module, does not cause the importing module to add a
+        non-backwards-compatible-revision statement to the revision history.
+        Non-backwards-compatible marking does not carry through import statements.
+        </t>
+        <t>A node compatibility statement at a leaf, leaf-list or typedef context
+        takes precedence over a node compatibility statement in a typedef
+        used by the leaf, leaf-list or typedef. If multiple typedefs with 
+        compatibility statements are used by a leaf, leaf-list or typedef (e.g. a union), and there 
+        is no compatibility statement at the top leaf, leaf-list or typedef context, then
+        the order of precedence used to classify the compatibility of the top level leaf, 
+        leaf-list or typedef is as follows: nbc-change-at, bc-change-at and finally 
+        editorial-change-at. That is, the leaf, leaf-list or typedef takes the most 
+        impactful change classification of all the underlying typedefs.</t>
+        <t>Node compatibility statements are not supported on YANG
+        statements such as 'pattern' or 'range'. The compatibility statement
+        instead goes against the leaf, leaf-list or typedef context.
+        </t>
+        <t>Node compatibility statements that refer to pre-release revisions of a module
+        MUST be removed when a full release revision of the module is published.
+        </t>
+        <t>Node compatibilty statements SHOULD NOT be used when it isn't clear which
+        change the statement is referring to. For example: If a leaf is reordered 
+        within a container, a node compatibility statement SHOULD NOT be used against
+        the parent container nor against the reordered leaf. Similarly, if a leaf
+        is renamed or moved to another context without keeping the old leaf present
+        in the model and marked obsolete, a node compatibilty statement SHOULD not
+        be used.
+        </t>       
       </section>
     </section>
     <section anchor="module_comparison_algorithm" numbered="true" toc="default">
@@ -298,6 +457,141 @@ module ietf-yang-rev-annotations {
       "XXXX: YANG Schema Comparison";
   }
 
+  extension nbc-change-at {
+    argument revision-date-or-label;
+    description
+      "A node compatibility statement that identifies a revision 
+      (by revision-label, or revision date if a revision-label is
+      not available) where a non-backwards-compatible change has 
+      occurred in a particular YANG statement relative to the
+      previous revision listed in the revision history.
+ 
+      The format of the revision-label argument MUST conform to the
+      pattern defined for the ietf-yang-revisions
+      revision-date-or-label typedef.
+
+      The following YANG statements MAY have zero or more 
+      nbc-change-at substatements:
+        - all schema node statements (leaf, rpc, choice, etc)
+        - 'feature' statements
+        - 'grouping' statements
+        - 'identity' statements
+        - 'must' statements
+        - 'refine' statements
+        - 'typedef' statements
+        - YANG extensions
+                          
+      Each YANG statement MUST only a have a single node
+      compatibilty statement (one of nbc-change-at, bc-change-at
+      or editorial-change-at) for a particular revision. When a node
+      has more than one of the node compatibilty statements (for 
+      different revisions), they must be ordered from most recent
+      to least recent.
+       
+      An nbc-change-at statement can have 0 or 1 'description' 
+      substatements.
+       
+      The nbc-change-at statement in not inherited by descendants
+      in the schema tree. It only applies to the specific YANG 
+      statement with which it is associated.   
+      ";
+       
+    reference
+      "XXXX: YANG Schema Comparison;
+       Section XXX, XXX";
+      
+  }
+
+  extension bc-change-at {
+    argument revision-date-or-label;
+    description
+      "A node compatibility statement that identifies a revision 
+      (by revision-label, or revision date if a revision-label is
+      not available) where a backwards-compatible change has 
+      occurred in a particular YANG statement relative to the
+      previous revision listed in the revision history.
+ 
+      The format of the revision-label argument MUST conform to the
+      pattern defined for the ietf-yang-revisions
+      revision-date-or-label typedef.
+
+      The following YANG statements MAY have zero or more 
+      bc-change-at substatements:
+        - all schema node statements (leaf, rpc, choice, etc)
+        - 'feature' statements
+        - 'grouping' statements
+        - 'identity' statements
+        - 'must' statements
+        - 'refine' statements
+        - 'typedef' statements
+        - YANG extensions
+                          
+      Each YANG statement MUST only a have a single node
+      compatibilty statement (one of nbc-change-at, bc-change-at
+      or editorial-change-at) for a particular revision. When a node
+      has more than one of the node compatibilty statements (for 
+      different revisions), they must be ordered from most recent
+      to least recent.
+       
+      An bc-change-at statement can have 0 or 1 'description' 
+      substatements.
+       
+      The bc-change-at statement in not inherited by descendants
+      in the schema tree. It only applies to the specific YANG 
+      statement with which it is associated.   
+      ";
+       
+    reference
+      "XXXX: YANG Schema Comparison;
+       Section XXX, XXX";
+      
+  }
+
+  extension editorial-change-at {
+    argument revision-date-or-label;
+    description
+      "A node compatibility statement that identifies a revision 
+      (by revision-label, or revision date if a revision-label is
+      not available) where an editorial change has 
+      occurred in a particular YANG statement relative to the
+      previous revision listed in the revision history.
+ 
+      The format of the revision-label argument MUST conform to the
+      pattern defined for the ietf-yang-revisions
+      revision-date-or-label typedef.
+
+      The following YANG statements MAY have zero or more 
+      editorial-change-at substatements:
+        - all schema node statements (leaf, rpc, choice, etc)
+        - 'feature' statements
+        - 'grouping' statements
+        - 'identity' statements
+        - 'must' statements
+        - 'refine' statements
+        - 'typedef' statements
+        - YANG extensions
+                          
+      Each YANG statement MUST only a have a single node
+      compatibilty statement (one of nbc-change-at, bc-change-at
+      or editorial-change-at) for a particular revision. When a node
+      has more than one of the node compatibilty statements (for 
+      different revisions), they must be ordered from most recent
+      to least recent.
+       
+      An editorial-change-at statement can have 0 or 1 'description' 
+      substatements.
+       
+      The editorial-change-at statement in not inherited by descendants
+      in the schema tree. It only applies to the specific YANG 
+      statement with which it is associated.   
+      ";
+       
+    reference
+      "XXXX: YANG Schema Comparison;
+       Section XXX, XXX";
+      
+  }
+  
   extension backwards-compatible {
     argument revision-date-or-label;
     description


### PR DESCRIPTION
Could not run xml2rfc on schema comparison. We'll have to fix that up later (previous version didn't work either).