### PR TITLE
Fix references resolved by xml2rfc

### DIFF
--- a/yang-module-versioning/draft-ietf-netmod-yang-module-versioning.xml
+++ b/yang-module-versioning/draft-ietf-netmod-yang-module-versioning.xml
@@ -1295,25 +1295,24 @@ module ietf-yang-library-revisions {
 <?rfc needLines="20"?>
 <back>
 <references title="Normative References">
-   <?rfc include='reference.RFC.2119'?>
-   <?rfc include='reference.RFC.3688'?>
-   <?rfc include='reference.RFC.6020'?>
-   <?rfc include='reference.RFC.8174'?>
-   <?rfc include='reference.RFC.7950'?>
-   <?rfc include='reference.RFC.8407'?>
-   <?rfc include='reference.RFC.8525'?>
-   <?ref include='reference.I-D.ietf-netmod-yang-semver'?>
-   <?ref include='reference.I-D.ietf-netmod-rfc6991-bis'?>
+   <?rfc include='reference.RFC.2119.xml'?>
+   <?rfc include='reference.RFC.3688.xml'?>
+   <?rfc include='reference.RFC.6020.xml'?>
+   <?rfc include='reference.RFC.8174.xml'?>
+   <?rfc include='reference.RFC.7950.xml'?>
+   <?rfc include='reference.RFC.8407.xml'?>
+   <?rfc include='reference.RFC.8525.xml'?>
+   <?ref include='reference.I-D.ietf-netmod-yang-semver.xml'?>
 </references>
 <references title="Informative References">
-   <?rfc include='reference.RFC.8340'?>
-   <?rfc include='reference.I-D.clacla-netmod-yang-model-update'?>
-   <?rfc include='reference.I-D.ietf-netmod-yang-instance-file-format'?>
-   <?rfc include='reference.I-D.ietf-netmod-yang-packages'?>
-   <?ref include='reference.I-D.ietf-netmod-yang-ver-selection'?>
-   <?rfc include="reference.I-D.ietf-netmod-yang-solutions"?>
-   <?ref include='reference.I-D.ietf-netmod-yang-versioning-reqs'?>
-   <?ref include='reference.I-D.ietf-netmod-yang-schema-comparison'?>
+   <?rfc include='reference.RFC.8340.xml'?>
+   <?rfc include='reference.I-D.clacla-netmod-yang-model-update.xml'?>
+   <?rfc include='reference.I-D.ietf-netmod-yang-instance-file-format.xml'?>
+   <?rfc include='reference.I-D.ietf-netmod-yang-packages.xml'?>
+   <?ref include='reference.I-D.ietf-netmod-yang-ver-selection.xml'?>
+   <?rfc include='reference.I-D.ietf-netmod-yang-solutions.xml'?>
+   <?ref include='reference.I-D.ietf-netmod-yang-versioning-reqs.xml'?>
+   <?ref include='reference.I-D.ietf-netmod-yang-schema-comparison.xml'?>
    <reference anchor="semver" target="https://www.semver.org">
       <front>
         <title>Semantic Versioning 2.0.0</title>


### PR DESCRIPTION
The xml2rfc tool could not resolve the references in the yang-module-versioning draft.

Also removes rfc-6991-bis reference, unused import, see #172.