### PR TITLE
Add the RFC 8407 security considerations template.

### DIFF
--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -6,14 +6,14 @@ Network Working Group                                     J. Clarke, Ed.
 Internet-Draft                                            R. Wilton, Ed.
 Updates: 8407 (if approved)                          Cisco Systems, Inc.
 Intended status: Standards Track                               R. Rahman
-Expires: 27 April 2023                                                  
+Expires: 2 June 2023                                                    
                                                               B. Lengyel
                                                                 Ericsson
                                                                J. Sterne
                                                                    Nokia
                                                                B. Claise
                                                                   Huawei
-                                                         24 October 2022
+                                                        29 November 2022
 
 
                         YANG Semantic Versioning
@@ -42,7 +42,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 27 April 2023.
+   This Internet-Draft will expire on 2 June 2023.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Clarke, et al.            Expires 27 April 2023                 [Page 1]
+Clarke, et al.             Expires 2 June 2023                  [Page 1]
 
-Internet-Draft                 YANG Semver                  October 2022
+Internet-Draft                 YANG Semver                 November 2022
 
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -92,13 +92,13 @@ Table of Contents
    7.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  20
    8.  Security Considerations . . . . . . . . . . . . . . . . . . .  20
    9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  20
-     9.1.  YANG Module Registrations . . . . . . . . . . . . . . . .  20
+     9.1.  YANG Module Registrations . . . . . . . . . . . . . . . .  21
      9.2.  Guidance for YANG Semver in IANA maintained YANG modules
            and submodules  . . . . . . . . . . . . . . . . . . . . .  21
-   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  21
+   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  22
      10.1.  Normative References . . . . . . . . . . . . . . . . . .  22
-     10.2.  Informative References . . . . . . . . . . . . . . . . .  22
-   Appendix A.  Example IETF Module Development  . . . . . . . . . .  23
+     10.2.  Informative References . . . . . . . . . . . . . . . . .  23
+   Appendix A.  Example IETF Module Development  . . . . . . . . . .  24
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  25
 
 
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Clarke, et al.            Expires 27 April 2023                 [Page 2]
+Clarke, et al.             Expires 2 June 2023                  [Page 2]
 
-Internet-Draft                 YANG Semver                  October 2022
+Internet-Draft                 YANG Semver                 November 2022
 
 
 1.  Introduction
@@ -165,9 +165,9 @@ Internet-Draft                 YANG Semver                  October 2022
 
 
 
-Clarke, et al.            Expires 27 April 2023                 [Page 3]
+Clarke, et al.             Expires 2 June 2023                  [Page 3]
 
-Internet-Draft                 YANG Semver                  October 2022
+Internet-Draft                 YANG Semver                 November 2022
 
 
    *  YANG Semver: A revision-label identifier that is consistent with
@@ -221,9 +221,9 @@ Internet-Draft                 YANG Semver                  October 2022
 
 
 
-Clarke, et al.            Expires 27 April 2023                 [Page 4]
+Clarke, et al.             Expires 2 June 2023                  [Page 4]
 
-Internet-Draft                 YANG Semver                  October 2022
+Internet-Draft                 YANG Semver                 November 2022
 
 
    release metadata MUST be used during module and submodule development
@@ -277,9 +277,9 @@ Internet-Draft                 YANG Semver                  October 2022
 
 
 
-Clarke, et al.            Expires 27 April 2023                 [Page 5]
+Clarke, et al.             Expires 2 June 2023                  [Page 5]
 
-Internet-Draft                 YANG Semver                  October 2022
+Internet-Draft                 YANG Semver                 November 2022
 
 
    Because the rules put forth in
@@ -333,9 +333,9 @@ Internet-Draft                 YANG Semver                  October 2022
 
 
 
-Clarke, et al.            Expires 27 April 2023                 [Page 6]
+Clarke, et al.             Expires 2 June 2023                  [Page 6]
 
-Internet-Draft                 YANG Semver                  October 2022
+Internet-Draft                 YANG Semver                 November 2022
 
 
       -  If, however, the modifier string is present, the meaning is
@@ -389,9 +389,9 @@ Internet-Draft                 YANG Semver                  October 2022
 
 
 
-Clarke, et al.            Expires 27 April 2023                 [Page 7]
+Clarke, et al.             Expires 2 June 2023                  [Page 7]
 
-Internet-Draft                 YANG Semver                  October 2022
+Internet-Draft                 YANG Semver                 November 2022
 
 
          3.5.0 -- 3.6.0 (add leaf foo)
@@ -445,9 +445,9 @@ Internet-Draft                 YANG Semver                  October 2022
 
 
 
-Clarke, et al.            Expires 27 April 2023                 [Page 8]
+Clarke, et al.             Expires 2 June 2023                  [Page 8]
 
-Internet-Draft                 YANG Semver                  October 2022
+Internet-Draft                 YANG Semver                 November 2022
 
 
    YANG Semantic versions for an example module:
@@ -501,9 +501,9 @@ Internet-Draft                 YANG Semver                  October 2022
 
 
 
-Clarke, et al.            Expires 27 April 2023                 [Page 9]
+Clarke, et al.             Expires 2 June 2023                  [Page 9]
 
-Internet-Draft                 YANG Semver                  October 2022
+Internet-Draft                 YANG Semver                 November 2022
 
 
       3.0.0 - NBC bugfix, rename "baz" to "bar"; also add new BC leaf
@@ -557,9 +557,9 @@ Internet-Draft                 YANG Semver                  October 2022
 
 
 
-Clarke, et al.            Expires 27 April 2023                [Page 10]
+Clarke, et al.             Expires 2 June 2023                 [Page 10]
 
-Internet-Draft                 YANG Semver                  October 2022
+Internet-Draft                 YANG Semver                 November 2022
 
 
    The following four rules specify the RECOMMENDED, and REQUIRED
@@ -613,9 +613,9 @@ Internet-Draft                 YANG Semver                  October 2022
 
 
 
-Clarke, et al.            Expires 27 April 2023                [Page 11]
+Clarke, et al.             Expires 2 June 2023                 [Page 11]
 
-Internet-Draft                 YANG Semver                  October 2022
+Internet-Draft                 YANG Semver                 November 2022
 
 
    Although artifacts SHOULD be updated according to the rules above,
@@ -669,9 +669,9 @@ Internet-Draft                 YANG Semver                  October 2022
 
 
 
-Clarke, et al.            Expires 27 April 2023                [Page 12]
+Clarke, et al.             Expires 2 June 2023                 [Page 12]
 
-Internet-Draft                 YANG Semver                  October 2022
+Internet-Draft                 YANG Semver                 November 2022
 
 
      module example-versioned-module {
@@ -725,9 +725,9 @@ Internet-Draft                 YANG Semver                  October 2022
 
 
 
-Clarke, et al.            Expires 27 April 2023                [Page 13]
+Clarke, et al.             Expires 2 June 2023                 [Page 13]
 
-Internet-Draft                 YANG Semver                  October 2022
+Internet-Draft                 YANG Semver                 November 2022
 
 
        //   rev:non-backwards-compatible; // optional
@@ -781,9 +781,9 @@ Internet-Draft                 YANG Semver                  October 2022
 
 
 
-Clarke, et al.            Expires 27 April 2023                [Page 14]
+Clarke, et al.             Expires 2 June 2023                 [Page 14]
 
-Internet-Draft                 YANG Semver                  October 2022
+Internet-Draft                 YANG Semver                 November 2022
 
 
    Note: the import lookup does not stop when a non-backward-compatible
@@ -837,9 +837,9 @@ Internet-Draft                 YANG Semver                  October 2022
 
 
 
-Clarke, et al.            Expires 27 April 2023                [Page 15]
+Clarke, et al.             Expires 2 June 2023                 [Page 15]
 
-Internet-Draft                 YANG Semver                  October 2022
+Internet-Draft                 YANG Semver                 November 2022
 
 
    When developing a new revision of an existing module or submodule
@@ -893,9 +893,9 @@ Internet-Draft                 YANG Semver                  October 2022
 
 
 
-Clarke, et al.            Expires 27 April 2023                [Page 16]
+Clarke, et al.             Expires 2 June 2023                 [Page 16]
 
-Internet-Draft                 YANG Semver                  October 2022
+Internet-Draft                 YANG Semver                 November 2022
 
 
 5.2.  YANG Semver in IETF Modules
@@ -949,9 +949,9 @@ Internet-Draft                 YANG Semver                  October 2022
 
 
 
-Clarke, et al.            Expires 27 April 2023                [Page 17]
+Clarke, et al.             Expires 2 June 2023                 [Page 17]
 
-Internet-Draft                 YANG Semver                  October 2022
+Internet-Draft                 YANG Semver                 November 2022
 
 
    YANG Semver would be 1.2.0 (since 1.0.0 would have been the initial,
@@ -1005,9 +1005,9 @@ Internet-Draft                 YANG Semver                  October 2022
 
 
 
-Clarke, et al.            Expires 27 April 2023                [Page 18]
+Clarke, et al.             Expires 2 June 2023                 [Page 18]
 
-Internet-Draft                 YANG Semver                  October 2022
+Internet-Draft                 YANG Semver                 November 2022
 
 
         Relating to IETF Documents
@@ -1061,9 +1061,9 @@ Internet-Draft                 YANG Semver                  October 2022
 
 
 
-Clarke, et al.            Expires 27 April 2023                [Page 19]
+Clarke, et al.             Expires 2 June 2023                 [Page 19]
 
-Internet-Draft                 YANG Semver                  October 2022
+Internet-Draft                 YANG Semver                 November 2022
 
 
        reference
@@ -1092,10 +1092,35 @@ Internet-Draft                 YANG Semver                  October 2022
 
 8.  Security Considerations
 
-   The document does not define any new protocol or data model.  There
-   are no security impacts.
+   The YANG module specified in this document defines a schema for data
+   that is designed to be accessed via network management protocols such
+   as NETCONF [RFC6241] or RESTCONF [RFC8040].  The lowest NETCONF layer
+   is the secure transport layer, and the mandatory-to-implement secure
+   transport is Secure Shell (SSH) [RFC6242].  The lowest RESTCONF layer
+   is HTTPS, and the mandatory-to-implement secure transport is TLS
+   [RFC8446].
+
+   The NETCONF access control model [RFC8341] provides the means to
+   restrict access for particular NETCONF or RESTCONF users to a
+   preconfigured subset of all available NETCONF or RESTCONF protocol
+   operations and content.
+
+   That said, the YANG module in this document does not define any
+   schema nodes (i.e., nothing that can be read or written).  It only
+   defines a typedef and an identity.  Therefore, there is no need to
+   further protect any nodes with access control.
 
 9.  IANA Considerations
+
+
+
+
+
+
+Clarke, et al.             Expires 2 June 2023                 [Page 20]
+
+Internet-Draft                 YANG Semver                 November 2022
+
 
 9.1.  YANG Module Registrations
 
@@ -1114,13 +1139,6 @@ Internet-Draft                 YANG Semver                  October 2022
    following registrations are requested:
 
    The ietf-yang-semver module:
-
-
-
-Clarke, et al.            Expires 27 April 2023                [Page 20]
-
-Internet-Draft                 YANG Semver                  October 2022
-
 
       Name: ietf-yang-semver
 
@@ -1150,6 +1168,16 @@ Internet-Draft                 YANG Semver                  October 2022
    The YANG Semver version associated with the new revision MUST follow
    the rules defined in Section 3.4 .
 
+
+
+
+
+
+Clarke, et al.             Expires 2 June 2023                 [Page 21]
+
+Internet-Draft                 YANG Semver                 November 2022
+
+
    Note: For IANA maintained YANG modules and submodules that have
    already been published, revision labels MUST be retroactively applied
    to all existing revisions when the next new revision is created,
@@ -1169,14 +1197,6 @@ Internet-Draft                 YANG Semver                  October 2022
    version element.
 
 10.  References
-
-
-
-
-Clarke, et al.            Expires 27 April 2023                [Page 21]
-
-Internet-Draft                 YANG Semver                  October 2022
-
 
 10.1.  Normative References
 
@@ -1206,6 +1226,14 @@ Internet-Draft                 YANG Semver                  October 2022
    [I-D.ietf-netmod-yang-module-versioning]
               Wilton, R., Rahman, R., Lengyel, B., Clarke, J., and J.
               Sterne, "Updated YANG Module Revision Handling", Work in
+
+
+
+Clarke, et al.             Expires 2 June 2023                 [Page 22]
+
+Internet-Draft                 YANG Semver                 November 2022
+
+
               Progress, Internet-Draft, draft-ietf-netmod-yang-module-
               versioning-06, 10 July 2022,
               <https://www.ietf.org/archive/id/draft-ietf-netmod-yang-
@@ -1227,13 +1255,6 @@ Internet-Draft                 YANG Semver                  October 2022
               <https://www.ietf.org/archive/id/draft-ietf-netmod-yang-
               packages-03.txt>.
 
-
-
-Clarke, et al.            Expires 27 April 2023                [Page 22]
-
-Internet-Draft                 YANG Semver                  October 2022
-
-
    [I-D.ietf-netmod-yang-schema-comparison]
               Wilton, R., "YANG Schema Comparison", Work in Progress,
               Internet-Draft, draft-ietf-netmod-yang-schema-comparison-
@@ -1244,6 +1265,39 @@ Internet-Draft                 YANG Semver                  October 2022
               and R. Wilton, "Network Management Datastore Architecture
               (NMDA)", RFC 8342, DOI 10.17487/RFC8342, March 2018,
               <https://www.rfc-editor.org/info/rfc8342>.
+
+   [RFC6241]  Enns, R., Ed., Bjorklund, M., Ed., Schoenwaelder, J., Ed.,
+              and A. Bierman, Ed., "Network Configuration Protocol
+              (NETCONF)", RFC 6241, DOI 10.17487/RFC6241, June 2011,
+              <https://www.rfc-editor.org/info/rfc6241>.
+
+   [RFC6242]  Wasserman, M., "Using the NETCONF Protocol over Secure
+              Shell (SSH)", RFC 6242, DOI 10.17487/RFC6242, June 2011,
+              <https://www.rfc-editor.org/info/rfc6242>.
+
+   [RFC8040]  Bierman, A., Bjorklund, M., and K. Watsen, "RESTCONF
+              Protocol", RFC 8040, DOI 10.17487/RFC8040, January 2017,
+              <https://www.rfc-editor.org/info/rfc8040>.
+
+
+
+
+
+
+
+Clarke, et al.             Expires 2 June 2023                 [Page 23]
+
+Internet-Draft                 YANG Semver                 November 2022
+
+
+   [RFC8341]  Bierman, A. and M. Bjorklund, "Network Configuration
+              Access Control Model", STD 91, RFC 8341,
+              DOI 10.17487/RFC8341, March 2018,
+              <https://www.rfc-editor.org/info/rfc8341>.
+
+   [RFC8446]  Rescorla, E., "The Transport Layer Security (TLS) Protocol
+              Version 1.3", RFC 8446, DOI 10.17487/RFC8446, August 2018,
+              <https://www.rfc-editor.org/info/rfc8446>.
 
    [openconfigsemver]
               "Semantic Versioning for Openconfig Models",
@@ -1281,18 +1335,16 @@ Appendix A.  Example IETF Module Development
            |
          0.2.1-draft-jdoe-netmod-example-module-03
 
-
-
-
-
-Clarke, et al.            Expires 27 April 2023                [Page 23]
-
-Internet-Draft                 YANG Semver                  October 2022
-
-
    At this point, development stabilizes, and the workgroup adopts the
    draft.  Thus now the draft becomes draft-ietf-netmod-example-module.
    The initial pre-release lineage continues as follows.
+
+
+
+Clarke, et al.             Expires 2 June 2023                 [Page 24]
+
+Internet-Draft                 YANG Semver                 November 2022
+
 
    Continued version lineage after adoption:
 
@@ -1338,15 +1390,17 @@ Internet-Draft                 YANG Semver                  October 2022
 
    The draft is ratified, and the new module version becomes 1.1.0.
 
-
-
-
-Clarke, et al.            Expires 27 April 2023                [Page 24]
-
-Internet-Draft                 YANG Semver                  October 2022
-
-
 Authors' Addresses
+
+
+
+
+
+
+Clarke, et al.             Expires 2 June 2023                 [Page 25]
+
+Internet-Draft                 YANG Semver                 November 2022
+
 
    Joe Clarke (editor)
    Cisco Systems, Inc.
@@ -1397,4 +1451,6 @@ Authors' Addresses
 
 
 
-Clarke, et al.            Expires 27 April 2023                [Page 25]
+
+
+Clarke, et al.             Expires 2 June 2023                 [Page 26]

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -766,8 +766,20 @@ module ietf-yang-semver {
 </section>
 <section anchor="security" numbered="true" toc="default">
 <name>Security Considerations</name>
-<t>The document does not define any new protocol or data model.  There
-  are no security impacts.</t>
+<t>The YANG module specified in this document defines a schema for data
+that is designed to be accessed via network management protocols such
+as NETCONF <xref target="RFC6241"/> or RESTCONF <xref target="RFC8040"/>.  The lowest NETCONF layer
+is the secure transport layer, and the mandatory-to-implement secure
+transport is Secure Shell (SSH) <xref target="RFC6242"/>.  The lowest RESTCONF layer
+is HTTPS, and the mandatory-to-implement secure transport is TLS
+<xref target="RFC8446"/>.</t>
+<t>The NETCONF access control model <xref target="RFC8341"/> provides the means to
+restrict access for particular NETCONF or RESTCONF users to a
+preconfigured subset of all available NETCONF or RESTCONF protocol
+operations and content.</t>
+<t>That said, the YANG module in this document does not define any schema nodes
+(i.e., nothing that can be read or written).  It only defines a typedef and an identity.
+    Therefore, there is no need to further protect any nodes with access control.</t>
 </section>
 <section anchor="iana" numbered="true" toc="default">
 <name>IANA Considerations</name>
@@ -849,6 +861,11 @@ module ietf-yang-semver {
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-netmod-yang-packages.xml"/>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-netmod-yang-schema-comparison.xml"/>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8342.xml"/>
+<xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6241.xml"/>
+<xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6242.xml"/>
+<xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8040.xml"/>
+<xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8341.xml"/>
+<xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8446.xml"/>
 <reference anchor="openconfigsemver" target="http://www.openconfig.net/docs/semver/">
 <front>
 <title>Semantic Versioning for Openconfig Models</title>


### PR DESCRIPTION
This folds in the Security considerations template, and then states that it's not really relevant.  A counter example to this is MUD: https://datatracker.ietf.org/doc/html/rfc8520.  Since that is not something accessed via NETCONF, we might not have to do the full template.  Thoughts?