### PR TITLE
Ietf 118 yang semver update

### DIFF
--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -95,8 +95,8 @@ Table of Contents
    7.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  21
    8.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  22
    9.  Security Considerations . . . . . . . . . . . . . . . . . . .  22
-   10. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  22
-     10.1.  YANG Module Registrations  . . . . . . . . . . . . . . .  22
+   10. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  23
+     10.1.  YANG Module Registrations  . . . . . . . . . . . . . . .  23
      10.2.  Guidance for YANG Semver in IANA maintained YANG modules
             and submodules . . . . . . . . . . . . . . . . . . . . .  23
    11. References  . . . . . . . . . . . . . . . . . . . . . . . . .  24
@@ -1035,6 +1035,12 @@ Internet-Draft                 YANG Semver                  January 2024
         Relating to IETF Documents
         (http://trustee.ietf.org/license-info).
 
+        The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+        NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+        'MAY', and 'OPTIONAL' in this document are to be interpreted as
+        described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+        they appear in all capitals, as shown here.
+
         This version of this YANG module is part of RFC XXXX; see
         the RFC itself for full legal notices.";
 
@@ -1052,12 +1058,6 @@ Internet-Draft                 YANG Semver                  January 2024
          "RFC XXXX: YANG Semantic Versioning.";
      }
 
-     /*
-      * Extensions
-      */
-
-     extension version {
-       argument yang-semantic-version;
 
 
 
@@ -1066,6 +1066,12 @@ Clarke, et al.            Expires 26 July 2024                 [Page 19]
 Internet-Draft                 YANG Semver                  January 2024
 
 
+     /*
+      * Extensions
+      */
+
+     extension version {
+       argument yang-semantic-version;
        description
          "The version can be used to provide an additional
           identifier associated with a module or submodule
@@ -1108,12 +1114,6 @@ Internet-Draft                 YANG Semver                  January 2024
           standardized.
 
           If specified multiple times, then any module revision that
-          satisfies at least one of the 'recommended-min-version'
-          statements is an acceptable recommended version for
-          import.
-
-          A particular version of an imported module adheres to an
-          import's 'recommended-min-version' extension statement if one
 
 
 
@@ -1122,6 +1122,12 @@ Clarke, et al.            Expires 26 July 2024                 [Page 20]
 Internet-Draft                 YANG Semver                  January 2024
 
 
+          satisfies at least one of the 'recommended-min-version'
+          statements is an acceptable recommended version for
+          import.
+
+          A particular version of an imported module adheres to an
+          import's 'recommended-min-version' extension statement if one
           of the following conditions are met:
 
           * Has the same MAJOR and MINOR version numbers and same or
@@ -1161,14 +1167,8 @@ Internet-Draft                 YANG Semver                  January 2024
 
    The following people made substantial contributions to this document:
 
-     Bo Wu
-     lana.wubo@huawei.com
-
-     Jan Lindblad
-     jlindbla@cisco.com
 
 
-                                  Figure 2
 
 
 
@@ -1177,6 +1177,15 @@ Clarke, et al.            Expires 26 July 2024                 [Page 21]
 
 Internet-Draft                 YANG Semver                  January 2024
 
+
+     Bo Wu
+     lana.wubo@huawei.com
+
+     Jan Lindblad
+     jlindbla@cisco.com
+
+
+                                  Figure 2
 
 8.  Acknowledgments
 
@@ -1215,6 +1224,16 @@ Internet-Draft                 YANG Semver                  January 2024
    preconfigured subset of all available NETCONF or RESTCONF protocol
    operations and content.
 
+
+
+
+
+
+Clarke, et al.            Expires 26 July 2024                 [Page 22]
+
+Internet-Draft                 YANG Semver                  January 2024
+
+
    That said, the YANG module in this document does not define any
    writeable nodes.  The extensions defined are only used to document
    YANG artifacts.
@@ -1226,13 +1245,6 @@ Internet-Draft                 YANG Semver                  January 2024
    This document requests IANA to register a URI in the "IETF XML
    Registry" [RFC3688].  Following the format in RFC 3688, the following
    registration is requested.
-
-
-
-Clarke, et al.            Expires 26 July 2024                 [Page 22]
-
-Internet-Draft                 YANG Semver                  January 2024
-
 
       URI: urn:ietf:params:xml:ns:yang:ietf-yang-semver
 
@@ -1270,6 +1282,14 @@ Internet-Draft                 YANG Semver                  January 2024
    IANA maintained YANG modules and submodules MUST also include a YANG
    Semver revision label for all new revisions, as defined in Section 3.
 
+
+
+
+Clarke, et al.            Expires 26 July 2024                 [Page 23]
+
+Internet-Draft                 YANG Semver                  January 2024
+
+
    The YANG Semver version associated with the new revision MUST follow
    the rules defined in Section 3.5.
 
@@ -1279,16 +1299,6 @@ Internet-Draft                 YANG Semver                  January 2024
    version "1.0.0" for the initial published revision, and then
    incrementing according to the YANG Semver rules specified in
    Section 3.5.
-
-
-
-
-
-
-Clarke, et al.            Expires 26 July 2024                 [Page 23]
-
-Internet-Draft                 YANG Semver                  January 2024
-
 
    Most changes to IANA maintained YANG modules and submodules are
    expected to be backwards-compatible changes and classified as MINOR
@@ -1328,16 +1338,6 @@ Internet-Draft                 YANG Semver                  January 2024
               DOI 10.17487/RFC8407, October 2018,
               <https://www.rfc-editor.org/info/rfc8407>.
 
-   [RFC7950]  Bjorklund, M., Ed., "The YANG 1.1 Data Modeling Language",
-              RFC 7950, DOI 10.17487/RFC7950, August 2016,
-              <https://www.rfc-editor.org/info/rfc7950>.
-
-
-
-
-
-
-
 
 
 
@@ -1345,6 +1345,10 @@ Clarke, et al.            Expires 26 July 2024                 [Page 24]
 
 Internet-Draft                 YANG Semver                  January 2024
 
+
+   [RFC7950]  Bjorklund, M., Ed., "The YANG 1.1 Data Modeling Language",
+              RFC 7950, DOI 10.17487/RFC7950, August 2016,
+              <https://www.rfc-editor.org/info/rfc7950>.
 
    [I-D.ietf-netmod-yang-module-versioning]
               Wilton, R., Rahman, R., Lengyel, B., Clarke, J., and J.
@@ -1391,16 +1395,16 @@ Internet-Draft                 YANG Semver                  January 2024
               Shell (SSH)", RFC 6242, DOI 10.17487/RFC6242, June 2011,
               <https://www.rfc-editor.org/info/rfc6242>.
 
-   [RFC8040]  Bierman, A., Bjorklund, M., and K. Watsen, "RESTCONF
-              Protocol", RFC 8040, DOI 10.17487/RFC8040, January 2017,
-              <https://www.rfc-editor.org/info/rfc8040>.
-
 
 
 Clarke, et al.            Expires 26 July 2024                 [Page 25]
 
 Internet-Draft                 YANG Semver                  January 2024
 
+
+   [RFC8040]  Bierman, A., Bjorklund, M., and K. Watsen, "RESTCONF
+              Protocol", RFC 8040, DOI 10.17487/RFC8040, January 2017,
+              <https://www.rfc-editor.org/info/rfc8040>.
 
    [RFC8341]  Bierman, A. and M. Bjorklund, "Network Configuration
               Access Control Model", STD 91, RFC 8341,
@@ -1443,10 +1447,6 @@ Appendix A.  Example IETF Module Development
    revision-label) of the module as it's being initially developed.
 
    Version lineage for initial module development:
-
-
-
-
 
 
 

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -6,14 +6,14 @@ Network Working Group                                     J. Clarke, Ed.
 Internet-Draft                                            R. Wilton, Ed.
 Updates: 8407, 8525, 7950 (if approved)              Cisco Systems, Inc.
 Intended status: Standards Track                               R. Rahman
-Expires: 2 September 2024                                        Equinix
+Expires: 3 September 2024                                        Equinix
                                                               B. Lengyel
                                                                 Ericsson
                                                                J. Sterne
                                                                    Nokia
                                                                B. Claise
                                                                   Huawei
-                                                            1 March 2024
+                                                            2 March 2024
 
 
                         YANG Semantic Versioning
@@ -43,7 +43,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 2 September 2024.
+   This Internet-Draft will expire on 3 September 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Clarke, et al.          Expires 2 September 2024                [Page 1]
+Clarke, et al.          Expires 3 September 2024                [Page 1]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -103,13 +103,13 @@ Table of Contents
    12. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  27
      12.1.  YANG Module Registrations  . . . . . . . . . . . . . . .  28
      12.2.  Guidance for YANG Semver in IANA maintained YANG modules
-            and submodules . . . . . . . . . . . . . . . . . . . . .  28
+            and submodules . . . . . . . . . . . . . . . . . . . . .  29
    13. References  . . . . . . . . . . . . . . . . . . . . . . . . .  29
      13.1.  Normative References . . . . . . . . . . . . . . . . . .  29
 
 
 
-Clarke, et al.          Expires 2 September 2024                [Page 2]
+Clarke, et al.          Expires 3 September 2024                [Page 2]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -165,7 +165,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024                [Page 3]
+Clarke, et al.          Expires 3 September 2024                [Page 3]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -221,7 +221,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024                [Page 4]
+Clarke, et al.          Expires 3 September 2024                [Page 4]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -277,7 +277,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024                [Page 5]
+Clarke, et al.          Expires 3 September 2024                [Page 5]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -333,7 +333,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024                [Page 6]
+Clarke, et al.          Expires 3 September 2024                [Page 6]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -389,7 +389,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024                [Page 7]
+Clarke, et al.          Expires 3 September 2024                [Page 7]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -445,7 +445,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024                [Page 8]
+Clarke, et al.          Expires 3 September 2024                [Page 8]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -501,7 +501,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024                [Page 9]
+Clarke, et al.          Expires 3 September 2024                [Page 9]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -557,7 +557,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024               [Page 10]
+Clarke, et al.          Expires 3 September 2024               [Page 10]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -613,7 +613,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024               [Page 11]
+Clarke, et al.          Expires 3 September 2024               [Page 11]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -669,7 +669,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024               [Page 12]
+Clarke, et al.          Expires 3 September 2024               [Page 12]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -725,7 +725,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024               [Page 13]
+Clarke, et al.          Expires 3 September 2024               [Page 13]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -781,7 +781,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024               [Page 14]
+Clarke, et al.          Expires 3 September 2024               [Page 14]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -837,7 +837,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024               [Page 15]
+Clarke, et al.          Expires 3 September 2024               [Page 15]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -893,7 +893,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024               [Page 16]
+Clarke, et al.          Expires 3 September 2024               [Page 16]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -949,7 +949,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024               [Page 17]
+Clarke, et al.          Expires 3 September 2024               [Page 17]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1005,7 +1005,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024               [Page 18]
+Clarke, et al.          Expires 3 September 2024               [Page 18]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1061,7 +1061,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024               [Page 19]
+Clarke, et al.          Expires 3 September 2024               [Page 19]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1117,7 +1117,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024               [Page 20]
+Clarke, et al.          Expires 3 September 2024               [Page 20]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1173,7 +1173,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024               [Page 21]
+Clarke, et al.          Expires 3 September 2024               [Page 21]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1229,7 +1229,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024               [Page 22]
+Clarke, et al.          Expires 3 September 2024               [Page 22]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1274,7 +1274,7 @@ Internet-Draft                 YANG Semver                    March 2024
      yang-version 1.1;
      namespace
        "urn:ietf:params:xml:ns:yang:ietf-yang-library-semver";
-     prefix yl-rev;
+     prefix yl-semver;
 
      import ietf-yang-semver {
        prefix ys;
@@ -1285,7 +1285,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024               [Page 23]
+Clarke, et al.          Expires 3 September 2024               [Page 23]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1341,7 +1341,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024               [Page 24]
+Clarke, et al.          Expires 3 September 2024               [Page 24]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1397,7 +1397,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024               [Page 25]
+Clarke, et al.          Expires 3 September 2024               [Page 25]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1453,7 +1453,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024               [Page 26]
+Clarke, et al.          Expires 3 September 2024               [Page 26]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1509,16 +1509,16 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 2 September 2024               [Page 27]
+Clarke, et al.          Expires 3 September 2024               [Page 27]
 
 Internet-Draft                 YANG Semver                    March 2024
 
 
 12.1.  YANG Module Registrations
 
-   This document requests IANA to register a URI in the "IETF XML
+   This document requests IANA to register URIs in the "IETF XML
    Registry" [RFC3688].  Following the format in RFC 3688, the following
-   registration is requested.
+   registrations are requested.
 
       URI: urn:ietf:params:xml:ns:yang:ietf-yang-semver
 
@@ -1526,8 +1526,14 @@ Internet-Draft                 YANG Semver                    March 2024
 
       XML: N/A, the requested URI is an XML namespace.
 
-   The following YANG module is requested to be registered in the "IANA
-   Module Names" [RFC6020].  Following the format in RFC 6020, the
+      URI: urn:ietf:params:xml:ns:yang:ietf-yang-library-semver
+
+      Registrant Contact: The IESG.
+
+      XML: N/A, the requested URI is an XML namespace.
+
+   The following YANG modules are requested to be registered in the
+   "IANA Module Names" [RFC6020].  Following the format in RFC 6020, the
    following registrations are requested:
 
    The ietf-yang-semver module:
@@ -1539,6 +1545,30 @@ Internet-Draft                 YANG Semver                    March 2024
       Prefix: ys
 
       Reference: [RFCXXXX]
+
+   The ietf-yang-library-semver module:
+
+      Name: ietf-yang-library-semver
+
+      XML Namespace: urn:ietf:params:xml:ns:yang:ietf-yang-library-
+      semver
+
+      Prefix: yl-semver
+
+      Reference: [RFCXXXX]
+
+
+
+
+
+
+
+
+
+Clarke, et al.          Expires 3 September 2024               [Page 28]
+
+Internet-Draft                 YANG Semver                    March 2024
+
 
 12.2.  Guidance for YANG Semver in IANA maintained YANG modules and
        submodules
@@ -1559,16 +1589,6 @@ Internet-Draft                 YANG Semver                    March 2024
 
    The YANG Semver version associated with the new revision MUST follow
    the rules defined in Section 4.5.
-
-
-
-
-
-
-Clarke, et al.          Expires 2 September 2024               [Page 28]
-
-Internet-Draft                 YANG Semver                    March 2024
-
 
    Note: For IANA maintained YANG modules and submodules that have
    already been published, versions MUST be retroactively applied to all
@@ -1597,6 +1617,15 @@ Internet-Draft                 YANG Semver                    March 2024
               DOI 10.17487/RFC2119, March 1997,
               <https://www.rfc-editor.org/info/rfc2119>.
 
+
+
+
+
+Clarke, et al.          Expires 3 September 2024               [Page 29]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
    [RFC3688]  Mealling, M., "The IETF XML Registry", BCP 81, RFC 3688,
               DOI 10.17487/RFC3688, January 2004,
               <https://www.rfc-editor.org/info/rfc3688>.
@@ -1619,13 +1648,6 @@ Internet-Draft                 YANG Semver                    March 2024
               RFC 7950, DOI 10.17487/RFC7950, August 2016,
               <https://www.rfc-editor.org/info/rfc7950>.
 
-
-
-Clarke, et al.          Expires 2 September 2024               [Page 29]
-
-Internet-Draft                 YANG Semver                    March 2024
-
-
    [RFC8525]  Bierman, A., Bjorklund, M., Schoenwaelder, J., Watsen, K.,
               and R. Wilton, "YANG Library", RFC 8525,
               DOI 10.17487/RFC8525, March 2019,
@@ -1647,6 +1669,18 @@ Internet-Draft                 YANG Semver                    March 2024
               Draft, draft-clacla-netmod-yang-model-update-06, 2 July
               2018, <https://datatracker.ietf.org/doc/html/draft-clacla-
               netmod-yang-model-update-06>.
+
+
+
+
+
+
+
+
+Clarke, et al.          Expires 3 September 2024               [Page 30]
+
+Internet-Draft                 YANG Semver                    March 2024
+
 
    [I-D.ietf-netmod-yang-packages]
               Wilton, R., Rahman, R., Clarke, J., Sterne, J., and B. Wu,
@@ -1671,17 +1705,6 @@ Internet-Draft                 YANG Semver                    March 2024
               (NMDA)", RFC 8342, DOI 10.17487/RFC8342, March 2018,
               <https://www.rfc-editor.org/info/rfc8342>.
 
-
-
-
-
-
-
-Clarke, et al.          Expires 2 September 2024               [Page 30]
-
-Internet-Draft                 YANG Semver                    March 2024
-
-
    [RFC6241]  Enns, R., Ed., Bjorklund, M., Ed., Schoenwaelder, J., Ed.,
               and A. Bierman, Ed., "Network Configuration Protocol
               (NETCONF)", RFC 6241, DOI 10.17487/RFC6241, June 2011,
@@ -1703,6 +1726,17 @@ Internet-Draft                 YANG Semver                    March 2024
    [RFC8446]  Rescorla, E., "The Transport Layer Security (TLS) Protocol
               Version 1.3", RFC 8446, DOI 10.17487/RFC8446, August 2018,
               <https://www.rfc-editor.org/info/rfc8446>.
+
+
+
+
+
+
+
+Clarke, et al.          Expires 3 September 2024               [Page 31]
+
+Internet-Draft                 YANG Semver                    March 2024
+
 
    [RFC8792]  Watsen, K., Auerswald, E., Farrel, A., and Q. Wu,
               "Handling Long Lines in Content of Internet-Drafts and
@@ -1726,17 +1760,6 @@ Internet-Draft                 YANG Semver                    March 2024
               "iana-routing-types YANG Module",
               <https://www.iana.org/assignments/iana-routing-types/iana-
               routing-types.xhtml>.
-
-
-
-
-
-
-
-Clarke, et al.          Expires 2 September 2024               [Page 31]
-
-Internet-Draft                 YANG Semver                    March 2024
-
 
 Appendix A.  Example IETF Module Development
 
@@ -1762,6 +1785,15 @@ Appendix A.  Example IETF Module Development
 
    Continued version progression after adoption:
 
+
+
+
+
+Clarke, et al.          Expires 3 September 2024               [Page 32]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
        1.0.0-draft-ietf-netmod-example-module-00
          |
        1.0.0-draft-ietf-netmod-example-module-01
@@ -1786,14 +1818,6 @@ Appendix A.  Example IETF Module Development
 
    In parallel with (track 2):
 
-
-
-
-Clarke, et al.          Expires 2 September 2024               [Page 32]
-
-Internet-Draft                 YANG Semver                    March 2024
-
-
          1.1.0-draft-asmith-netmod-exmod-changes-00
            |
          1.1.0-draft-asmith-netmod-exmod-changes-01
@@ -1813,6 +1837,18 @@ Internet-Draft                 YANG Semver                    March 2024
    The draft is standardized, and the new module version becomes 1.1.0.
 
 Authors' Addresses
+
+
+
+
+
+
+
+
+Clarke, et al.          Expires 3 September 2024               [Page 33]
+
+Internet-Draft                 YANG Semver                    March 2024
+
 
    Joe Clarke (editor)
    Cisco Systems, Inc.
@@ -1842,14 +1878,6 @@ Authors' Addresses
    Email: balazs.lengyel@ericsson.com
 
 
-
-
-
-Clarke, et al.          Expires 2 September 2024               [Page 33]
-
-Internet-Draft                 YANG Semver                    March 2024
-
-
    Jason Sterne
    Nokia
    Email: jason.sterne@nokia.com
@@ -1873,32 +1901,4 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Clarke, et al.          Expires 2 September 2024               [Page 34]
+Clarke, et al.          Expires 3 September 2024               [Page 34]

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -1155,7 +1155,7 @@ Internet-Draft                 YANG Semver                    March 2024
      // note.
      // RFC Ed. update the ys:version to "1.0.0".
 
-     revision 2024-01-22 {
+     revision 2024-03-01 {
        ys:version "1.0.0-draft-ietf-netmod-yang-semver-13";
        description
          "Initial revision";

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -6,26 +6,26 @@ Network Working Group                                     J. Clarke, Ed.
 Internet-Draft                                            R. Wilton, Ed.
 Updates: 8407 (if approved)                          Cisco Systems, Inc.
 Intended status: Standards Track                               R. Rahman
-Expires: 4 April 2024                                          Graphiant
+Expires: 26 July 2024                                          Graphiant
                                                               B. Lengyel
                                                                 Ericsson
                                                                J. Sterne
                                                                    Nokia
                                                                B. Claise
                                                                   Huawei
-                                                          2 October 2023
+                                                         23 January 2024
 
 
                         YANG Semantic Versioning
-                    draft-ietf-netmod-yang-semver-12
+                    draft-ietf-netmod-yang-semver-13
 
 Abstract
 
-   This document specifies a scheme and guidelines for applying an
-   extended set of semantic versioning rules to revisions of YANG
-   artifacts (e.g., modules and packages).  Additionally, this document
-   defines an RFCAAAA-compliant revision-label-scheme for this YANG
-   semantic versioning scheme.
+   This document specifies a YANG extension along with guidelines
+   guidelines for applying an extended set of semantic versioning rules
+   to revisions of YANG artifacts (e.g., modules and packages).
+   Additionally, this document defines a YANG extension for controlling
+   module imports based on these modified semantic versioning rules.
 
 Status of This Memo
 
@@ -42,20 +42,20 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 4 April 2024.
+   This Internet-Draft will expire on 26 July 2024.
 
 Copyright Notice
 
-   Copyright (c) 2023 IETF Trust and the persons identified as the
+   Copyright (c) 2024 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
 
 
 
 
-Clarke, et al.            Expires 4 April 2024                  [Page 1]
+Clarke, et al.            Expires 26 July 2024                  [Page 1]
 
-Internet-Draft                 YANG Semver                  October 2023
+Internet-Draft                 YANG Semver                  January 2024
 
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -73,45 +73,45 @@ Table of Contents
    2.  Terminology and Conventions . . . . . . . . . . . . . . . . .   3
    3.  YANG Semantic Versioning  . . . . . . . . . . . . . . . . . .   4
      3.1.  Relationship Between SemVer and YANG Semver . . . . . . .   4
-     3.2.  YANG Semver Pattern . . . . . . . . . . . . . . . . . . .   4
-     3.3.  Semantic Versioning Scheme for YANG Artifacts . . . . . .   5
-       3.3.1.  Branching Limitations with YANG Semver  . . . . . . .   7
-       3.3.2.  YANG Semver with submodules . . . . . . . . . . . . .   8
-       3.3.3.  Examples for YANG semantic versions . . . . . . . . .   8
-     3.4.  YANG Semantic Version Update Rules  . . . . . . . . . . .  10
-     3.5.  Examples of the YANG Semver Label . . . . . . . . . . . .  12
-       3.5.1.  Example Module Using YANG Semver  . . . . . . . . . .  12
-       3.5.2.  Example of Package Using YANG Semver  . . . . . . . .  14
-   4.  Import Module by Semantic Version . . . . . . . . . . . . . .  15
+     3.2.  YANG Semantic Version Extension . . . . . . . . . . . . .   4
+     3.3.  YANG Semver Pattern . . . . . . . . . . . . . . . . . . .   4
+     3.4.  Semantic Versioning Scheme for YANG Artifacts . . . . . .   5
+       3.4.1.  Branching Limitations with YANG Semver  . . . . . . .   7
+       3.4.2.  YANG Semver with submodules . . . . . . . . . . . . .   8
+       3.4.3.  Examples for YANG semantic versions . . . . . . . . .   8
+     3.5.  YANG Semantic Version Update Rules  . . . . . . . . . . .  10
+     3.6.  Examples of the YANG Semver Label . . . . . . . . . . . .  12
+       3.6.1.  Example Module Using YANG Semver  . . . . . . . . . .  12
+       3.6.2.  Example of Package Using YANG Semver  . . . . . . . .  13
+   4.  Import Module by YANG Semantic Version  . . . . . . . . . . .  14
+     4.1.  The recommended-min-version Extension . . . . . . . . . .  14
+     4.2.  Import by YANG Semantic Version Rules . . . . . . . . . .  15
    5.  Guidelines for Using Semver During Module Development . . . .  15
      5.1.  Pre-release Version Precedence  . . . . . . . . . . . . .  17
      5.2.  YANG Semver in IETF Modules . . . . . . . . . . . . . . .  17
        5.2.1.  Guidelines for IETF Module Development  . . . . . . .  17
        5.2.2.  Guidelines for Published IETF Modules . . . . . . . .  18
    6.  YANG Module . . . . . . . . . . . . . . . . . . . . . . . . .  18
-   7.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  20
-   8.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  20
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  21
-   10. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  21
-     10.1.  YANG Module Registrations  . . . . . . . . . . . . . . .  21
+   7.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  21
+   8.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  22
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  22
+   10. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  22
+     10.1.  YANG Module Registrations  . . . . . . . . . . . . . . .  22
      10.2.  Guidance for YANG Semver in IANA maintained YANG modules
-            and submodules . . . . . . . . . . . . . . . . . . . . .  22
-   11. References  . . . . . . . . . . . . . . . . . . . . . . . . .  23
-     11.1.  Normative References . . . . . . . . . . . . . . . . . .  23
-     11.2.  Informative References . . . . . . . . . . . . . . . . .  23
-   Appendix A.  Example IETF Module Development  . . . . . . . . . .  25
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  26
+            and submodules . . . . . . . . . . . . . . . . . . . . .  23
+   11. References  . . . . . . . . . . . . . . . . . . . . . . . . .  24
+     11.1.  Normative References . . . . . . . . . . . . . . . . . .  24
+     11.2.  Informative References . . . . . . . . . . . . . . . . .  25
+   Appendix A.  Example IETF Module Development  . . . . . . . . . .  26
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  28
 
 
 
 
 
-
-
-
-Clarke, et al.            Expires 4 April 2024                  [Page 2]
+Clarke, et al.            Expires 26 July 2024                  [Page 2]
 
-Internet-Draft                 YANG Semver                  October 2023
+Internet-Draft                 YANG Semver                  January 2024
 
 
 1.  Introduction
@@ -122,20 +122,17 @@ Internet-Draft                 YANG Semver                  October 2023
    submodule has non-backwards-compatible (NBC) changes compared to its
    previous revision, and a scheme that uses the revision history as a
    lineage for determining from where a specific revision of a YANG
-   module or submodule is derived.  Additionally, section 3.4 of
-   [I-D.ietf-netmod-yang-module-versioning] defines a revision-label
-   which can be used as an alias to provide additional context or as a
-   meaningful label to refer to a specific revision.
+   module or submodule is derived.
 
-   This document defines a revision-label scheme that uses extended
-   semantic versioning rules [SemVer] for YANG artifacts (i.e., YANG
-   modules, YANG submodules, and YANG packages
-   [I-D.ietf-netmod-yang-packages] ) as well as the revision label
-   definition for using this scheme.  The goal being to add a human
-   readable revision label that provides compatibility information for
-   the YANG artifact without needing to compare or parse its body.  The
-   label and rules defined herein represent the RECOMMENDED revision
-   label scheme for IETF YANG artifacts.
+   This document defines a YANG extension that tags a YANG artifact
+   (i.e., YANG modules, YANG submodules, and YANG packages
+   [I-D.ietf-netmod-yang-packages] ) with a version identifier that
+   adheres to extended semantic versioning rules [SemVer].  The goal
+   being to add a human readable revision label that provides
+   compatibility information for the YANG artifact without needing to
+   compare or parse its body.  The version identifier and rules defined
+   herein represent the RECOMMENDED approach to apply versioning to IETF
+   YANG artifacts.
 
    Note that a specific revision of the SemVer 2.0.0 specification is
    referenced here (from June 19, 2020) to provide an immutable version.
@@ -158,21 +155,20 @@ Internet-Draft                 YANG Semver                  October 2023
       the purposes of this document.
 
    *  SemVer: A version string that corresponds to the rules defined in
-      [SemVer] .  This specific camel-case notation is the one used by
+      [SemVer].  This specific camel-case notation is the one used by
       the SemVer 2.0.0 website and used within this document to
       distinguish between YANG Semver.
 
-
-
-
-Clarke, et al.            Expires 4 April 2024                  [Page 3]
-
-Internet-Draft                 YANG Semver                  October 2023
-
-
-   *  YANG Semver: A revision-label identifier that is consistent with
-      the extended set of semantic versioning rules, based on [SemVer] ,
+   *  YANG Semver: A version identifier that is consistent with the
+      extended set of semantic versioning rules, based on [SemVer],
       defined within this document.
+
+
+
+Clarke, et al.            Expires 26 July 2024                  [Page 3]
+
+Internet-Draft                 YANG Semver                  January 2024
+
 
 3.  YANG Semantic Versioning
 
@@ -186,17 +182,25 @@ Internet-Draft                 YANG Semver                  October 2023
    [SemVer] is completely compatible with YANG Semver in that a SemVer
    semantic version number is legal according to the YANG Semver rules
    (though the inverse is not necessarily true).  YANG Semver is a
-   superset of the SemVer rules, and allow for limited branching within
+   superset of the SemVer rules, and allows for limited branching within
    YANG artifacts.  If no branching occurs within a YANG artifact (i.e.,
    you do not use the compatibility modifiers described below), the YANG
    Semver version label will appear as a SemVer version number.
 
-3.2.  YANG Semver Pattern
+3.2.  YANG Semantic Version Extension
+
+   The ietf-yang-semver module defines a "version" extension -- a
+   substatement to a module or submodule's "import" statement -- that
+   takes a YANG semantic version as its argument and specified the
+   version for the given module or submodule.  The syntax for the YANG
+   semantic version is defined in a typedef in the same module and
+   described below.
+
+3.3.  YANG Semver Pattern
 
    YANG artifacts that employ semantic versioning as defined in this
-   document MUST use a version string (e.g., in revision-label or as a
-   package version) that corresponds to the following pattern:
-   'X.Y.Z_COMPAT'.  Where:
+   document MUST use a version identifier that corresponds to the
+   following pattern: 'X.Y.Z_COMPAT'.  Where:
 
    *  X, Y and Z are mandatory non-negative integers that are each less
       than or equal to 2147483647 (i.e., the maximum signed 32-bit
@@ -214,38 +218,34 @@ Internet-Draft                 YANG Semver                  October 2023
    Additionally, [SemVer] defines two specific types of metadata that
    may be appended to a semantic version string.  Pre-release metadata
    MAY be appended to a YANG Semver string after a trailing '-'
+
+
+
+Clarke, et al.            Expires 26 July 2024                  [Page 4]
+
+Internet-Draft                 YANG Semver                  January 2024
+
+
    character.  Build metadata MAY be appended after a trailing '+'
    character.  If both pre-release and build metadata are present, then
    build metadata MUST follow pre-release metadata.  While build
    metadata MUST be ignored when comparing YANG semantic versions, pre-
-
-
-
-Clarke, et al.            Expires 4 April 2024                  [Page 4]
-
-Internet-Draft                 YANG Semver                  October 2023
-
-
    release metadata MUST be used during module and submodule development
-   as specified in Section 5 .  Both pre-release and build metadata are
+   as specified in Section 5.  Both pre-release and build metadata are
    allowed in order to support all the [SemVer] rules.  Thus, a version
    lineage that follows strict [SemVer] rules is allowed for a YANG
    artifact.
 
-   To signal the use of this versioning scheme, modules and submodules
-   MUST set the revision-label-scheme extension, as defined in
-   [I-D.ietf-netmod-yang-module-versioning] , to the identity "yang-
-   semver".  That identity value is defined in the ietf-yang-semver
-   module below.
+   The ietf-yang-semver module included in this document defines an
+   extension to apply a YANG Semver identifier to a YANG artifact as
+   well as a typedef that formally specifies the syntax of the YANG
+   Semver.
 
-   Additionally, this ietf-yang-semver module defines a typedef that
-   formally specifies the syntax of the YANG Semver.
-
-3.3.  Semantic Versioning Scheme for YANG Artifacts
+3.4.  Semantic Versioning Scheme for YANG Artifacts
 
    This document defines the YANG semantic versioning scheme that is
-   used for YANG artifacts that employ the YANG Semver label.  The
-   versioning scheme has the following properties:
+   used for YANG artifacts.  The versioning identifier has the following
+   properties:
 
    *  The YANG semantic versioning scheme is extended from version 2.0.0
       of the semantic versioning scheme defined at semver.org [SemVer]
@@ -259,36 +259,36 @@ Internet-Draft                 YANG Semver                  October 2023
       versions that are not the latest.  However, it does not provide
       for the unlimited branching and updating of older revisions which
       are documented by the general rules in
-      [I-D.ietf-netmod-yang-module-versioning] .
+      [I-D.ietf-netmod-yang-module-versioning].
 
-   *  YANG artifacts that follow the [SemVer] versioning scheme are
-      fully compatible with implementations that understand the YANG
-      semantic versioning scheme defined in this document.
+   *  YANG artifacts that use the [SemVer] versioning scheme are fully
+      compatible with implementations that understand the YANG semantic
+      versioning scheme defined in this document.
 
    *  If updates are always restricted to the latest revision of the
-      artifact only, then the version numbers used by the YANG semantic
-      versioning scheme are exactly the same as those defined by the
-      [SemVer] versioning scheme.
+      artifact only, then the version identifiers used by the YANG
+      semantic versioning scheme are exactly the same as those defined
+      by the [SemVer] versioning scheme.
 
    Every YANG module and submodule versioned using the YANG semantic
    versioning scheme specifies the module's or submodule's semantic
-   version as the argument to the 'rev:revision-label' statement.
+   version as the argument to the 'ysver:version' statement.
 
 
 
 
-Clarke, et al.            Expires 4 April 2024                  [Page 5]
+Clarke, et al.            Expires 26 July 2024                  [Page 5]
 
-Internet-Draft                 YANG Semver                  October 2023
+Internet-Draft                 YANG Semver                  January 2024
 
 
    Because the rules put forth in
    [I-D.ietf-netmod-yang-module-versioning] are designed to work well
    with existing versions of YANG and allow for artifact authors to
    migrate to this scheme, it is not expected that all revisions of a
-   given YANG artifact will have a semantic version label.  For example,
-   the first revision of a module or submodule may have been produced
-   before this scheme was available.
+   given YANG artifact will have a semantic version identifier.  For
+   example, the first revision of a module or submodule may have been
+   produced before this scheme was available.
 
    YANG packages that make use of this YANG Semver will reflect that in
    the package metadata.
@@ -333,9 +333,9 @@ Internet-Draft                 YANG Semver                  October 2023
 
 
 
-Clarke, et al.            Expires 4 April 2024                  [Page 6]
+Clarke, et al.            Expires 26 July 2024                  [Page 6]
 
-Internet-Draft                 YANG Semver                  October 2023
+Internet-Draft                 YANG Semver                  January 2024
 
 
       -  If, however, the modifier string is present, the meaning is
@@ -348,20 +348,20 @@ Internet-Draft                 YANG Semver                  October 2023
          compatible change
 
    The '_COMPAT' modifier string is "sticky".  Once a revision of a
-   module has a modifier in the revision label, then all descendants of
-   that revision with the same X.Y version digits will also have a
-   modifier.  The modifier can change from "_compatible" to
-   "_non_compatible" in a descendant revision, but the modifier MUST NOT
-   change from "_non_compatible" to "_compatible" and MUST NOT be
-   removed.  The persistence of the "_non_compatible" modifier ensures
-   that comparisons of revision labels do not give the false impression
-   of compatibility between two potentially non-compatible revisions.
-   If "_non_compatible" was removed, for example between revisions
-   "3.3.2_non_compatible" and "3.3.3" (where "3.3.3" was simply an
-   editorial change), then comparing revision labels of "3.3.3" back to
-   an ancestor "3.0.0" would look like they are backwards compatible
-   when they are not (since "3.3.2_non_compatible" was in the chain of
-   ancestors and introduced a non-backwards-compatible change).
+   module has a modifier in the revision label, then all subsequent
+   modules in that branch (i.e., those with the same X.Y version digits)
+   will also have a modifier.  The modifier can change from
+   "_compatible" to "_non_compatible" in a subsequent version, but the
+   modifier MUST NOT change from "_non_compatible" to "_compatible" and
+   MUST NOT be removed.  The persistence of the "_non_compatible"
+   modifier ensures that comparisons of versions do not give the false
+   impression of compatibility between two potentially non-compatible
+   versions.  If "_non_compatible" was removed, for example between
+   versions "3.3.2_non_compatible" and "3.3.3" (where "3.3.3" was simply
+   an editorial change), then comparing versions "3.3.3" to "3.0.0"
+   would look like they are backwards compatible when they are not
+   (since "3.3.2_non_compatible" was on the same MAJOR.MINOR branch and
+   introduced a non-backwards-compatible change).
 
    The YANG artifact name and YANG semantic version uniquely identify a
    revision of said artifact.  There MUST NOT be multiple instances of a
@@ -374,14 +374,14 @@ Internet-Draft                 YANG Semver                  October 2023
    modifier strings.  E.g., artifact version "1.2.3_non_compatible" MUST
    NOT be defined if artifact version "1.2.3" has already been defined.
 
-3.3.1.  Branching Limitations with YANG Semver
+3.4.1.  Branching Limitations with YANG Semver
 
-   YANG artifacts that use the YANG Semver revision-label scheme MUST
-   ensure that two artifacts with the same MAJOR version number and no
+   YANG artifacts that use the YANG Semver version scheme MUST ensure
+   that two artifacts with the same MAJOR version number and no
    _compatible or _non_compatible modifiers are backwards compatible.
    Therefore, certain branching schemes cannot be used with YANG Semver.
-   For example, the following branched parent-child module relationship
-   using the following YANG Semver revision labels is not supported:
+   For example, the following branching approach using the following
+   YANG Semver identifiers is not supported:
 
 
 
@@ -389,9 +389,9 @@ Internet-Draft                 YANG Semver                  October 2023
 
 
 
-Clarke, et al.            Expires 4 April 2024                  [Page 7]
+Clarke, et al.            Expires 26 July 2024                  [Page 7]
 
-Internet-Draft                 YANG Semver                  October 2023
+Internet-Draft                 YANG Semver                  January 2024
 
 
          3.5.0 -- 3.6.0 (add leaf foo)
@@ -399,17 +399,16 @@ Internet-Draft                 YANG Semver                  October 2023
            |
          3.20.0 (added leaf bar)
 
-   In this case, given only the revision labels 3.6.0 and 3.20.0 without
-   any parent-child relationship information, one would assume that
-   3.20.0 is backwards compatible with 3.6.0.  But in the illegal
-   example above, 3.20.0 is not backwards compatible with 3.6.0 since
-   3.20.0 does not contain the leaf foo.
+   In this case, given only the YANG Semver identifiers 3.6.0 and
+   3.20.0, one would assume that 3.20.0 is backwards compatible with
+   3.6.0.  But in the illegal example above, 3.20.0 is not backwards
+   compatible with 3.6.0 since 3.20.0 does not contain the leaf foo.
 
-   Note that this type of branched parent-child relationship, where two
-   revisions have different backwards compatible changes based on the
-   same parent, is allowed in [I-D.ietf-netmod-yang-module-versioning] .
+   Note that this type of branching, where two versions on the same
+   branch have different backwards compatible changes is allowed in
+   [I-D.ietf-netmod-yang-module-versioning].
 
-3.3.2.  YANG Semver with submodules
+3.4.2.  YANG Semver with submodules
 
    YANG Semver MAY be used to version submodules.  Submodule version are
    separate of any version on the including module, but if a submodule
@@ -417,12 +416,12 @@ Internet-Draft                 YANG Semver                  October 2023
    updated.
 
    The rules for determining the version change of a submodule are the
-   same as those defined in Section 3.2 and Section 3.3 as applied to
+   same as those defined in Section 3.3 and Section 3.4 as applied to
    YANG modules, except they only apply to the part of the module schema
    defined within the submodule's file.
 
    One interesting case is moving definitions from one submodule to
-   another in a way that does not change the resultant schema of the
+   another in a way that does not change the resulting schema of the
    including module.  In this case:
 
    1.  The including module has editorial changes
@@ -438,16 +437,17 @@ Internet-Draft                 YANG Semver                  October 2023
    submodules belonging to the same module (e.g. groupings and typedefs
    declared in one submodule and used in another).
 
-3.3.3.  Examples for YANG semantic versions
+3.4.3.  Examples for YANG semantic versions
 
    The following diagram and explanation illustrate how YANG semantic
    versions work.
 
 
 
-Clarke, et al.            Expires 4 April 2024                  [Page 8]
+
+Clarke, et al.            Expires 26 July 2024                  [Page 8]
 
-Internet-Draft                 YANG Semver                  October 2023
+Internet-Draft                 YANG Semver                  January 2024
 
 
    YANG Semantic versions for an example module:
@@ -470,13 +470,12 @@ Internet-Draft                 YANG Semver                  October 2023
 
    The tree diagram above illustrates how the version history might
    evolve for an example module.  The tree diagram only shows the
-   parent/child ancestry relationships between the revisions.  It does
-   not describe the chronology of the revisions (i.e.  when in time each
-   revision was published relative to the other revisions).
+   branching relationships between the versions.  It does not describe
+   the chronology of the versions (i.e.  when in time each version was
+   published relative to the other versions).
 
    The following description lists an example of what the chronological
-   order of the revisions could look like, from oldest revision to
-   newest:
+   order of the versions could look like, from oldest version to newest:
 
       0.1.0 - first pre-release module version
 
@@ -497,17 +496,15 @@ Internet-Draft                 YANG Semver                  October 2023
       implementing "baz" from 1.2.0.  This revision was created after
       1.2.0 otherwise it may have been released as 1.2.0.  (BC)
 
-
-
-
-
-Clarke, et al.            Expires 4 April 2024                  [Page 9]
-
-Internet-Draft                 YANG Semver                  October 2023
-
-
       3.0.0 - NBC bugfix, rename "baz" to "bar"; also add new BC leaf
       "wibble"; (NBC)
+
+
+
+Clarke, et al.            Expires 26 July 2024                  [Page 9]
+
+Internet-Draft                 YANG Semver                  January 2024
+
 
       1.3.1_non_compatible - backport NBC fix, rename "baz" to "bar"
       (NBC)
@@ -525,42 +522,13 @@ Internet-Draft                 YANG Semver                  October 2023
       1.2.2_non_compatible - backport "wibble".  This is a BC change but
       "non_compatible" modifier is sticky.  (BC)
 
-   The partial ancestry relationships based on the semantic versioning
-   numbers are as follows:
+3.5.  YANG Semantic Version Update Rules
 
-      1.0.0 < 1.1.0 < 1.2.0 < 2.0.0 < 3.0.0 < 3.1.0
-
-      1.0.0 < 1.1.0 < 1.1.1_compatible < 1.1.2_non_compatible
-
-      1.0.0 < 1.1.0 < 1.2.0 < 1.2.1_non_compatible <
-      1.2.2_non_compatible
-
-      1.0.0 < 1.1.0 < 1.2.0 < 1.3.0 < 1.3.1_non_compatible
-
-      1.0.0 < 1.1.0 < 1.2.0 < 1.3.0 < 1.4.0
-
-   There is no ordering relationship between "1.1.1_non_compatible" and
-   either "1.2.0" or "1.2.1_non_compatible", except that they share the
-   common ancestor of "1.1.0".
-
-   Looking at the version number alone does not indicate ancestry.  The
-   module definition in "2.0.0", for example, does not contain all the
-   contents of "1.3.0".  Version "2.0.0" is not derived from "1.3.0".
-
-3.4.  YANG Semantic Version Update Rules
-
-   When a new revision of an artifact is produced, then the following
-   rules define how the YANG semantic version for the new artifact
-   revision is calculated, based on the changes between the two artifact
-   revisions, and the YANG semantic version of the base artifact
-   revision from which the changes are derived.
-
-
-
-Clarke, et al.            Expires 4 April 2024                 [Page 10]
-
-Internet-Draft                 YANG Semver                  October 2023
-
+   When a new version of an artifact is produced, then the following
+   rules define how the YANG semantic version for the new artifact is
+   calculated, based on the changes between the two artifact versions,
+   and the YANG semantic version of the original artifact from which the
+   changes are derived.
 
    The following four rules specify the RECOMMENDED, and REQUIRED
    minimum, update to a YANG semantic version:
@@ -587,9 +555,16 @@ Internet-Draft                 YANG Semver                  October 2023
        iii  "X.Y.Z_non_compatible" - the artifact version SHOULD be
             updated to "X.Y.Z+1_non_compatible".
 
+
+
+Clarke, et al.            Expires 26 July 2024                 [Page 10]
+
+Internet-Draft                 YANG Semver                  January 2024
+
+
    3.  If an artifact is being updated in an editorial way, then the
-       next version number depends on the format of the current version
-       number:
+       next version identifier depends on the format of the current
+       version identifier:
 
        i    "X.Y.Z" - the artifact version SHOULD be updated to
             "X.Y.Z+1"
@@ -600,51 +575,48 @@ Internet-Draft                 YANG Semver                  October 2023
        iii  "X.Y.Z_non_compatible" - the artifact version SHOULD be
             updated to "X.Y.Z+1_non_compatible".
 
-   4.  YANG artifact semantic version numbers beginning with 0, i.e.,
-       "0.X.Y", are regarded as pre-release definitions and need not
-       follow the rules above.  Either the MINOR or PATCH version
+   4.  YANG artifact semantic version identifiers beginning with 0,
+       i.e., "0.X.Y", are regarded as pre-release definitions and need
+       not follow the rules above.  Either the MINOR or PATCH version
        numbers may be updated, regardless of whether the changes are
        non-backwards-compatible, backwards-compatible, or editorial.
        See Section 5 for more details on using this notation during
        module and submodule development.
 
    5.  Additional pre-release rules for modules that have had at least
-       one release are specified in Section 5 .
-
-
-
-Clarke, et al.            Expires 4 April 2024                 [Page 11]
-
-Internet-Draft                 YANG Semver                  October 2023
-
+       one release are specified in Section 5.
 
    Although artifacts SHOULD be updated according to the rules above,
    which specify the recommended (and minimum required) update to the
-   version number, the following rules MAY be applied when choosing a
-   new version number:
+   version identifier, the following rules MAY be applied when choosing
+   a new version identifier:
 
-   1.  An artifact author MAY update the version number with a more
+   1.  An artifact author MAY update the version identifier with a more
        significant update than described by the rules above.  For
        example, an artifact could be given a new MAJOR version number
        (i.e., X+1.0.0), even though no non-backwards-compatible changes
        have occurred, or an artifact could be given a new MINOR version
        number (i.e., X.Y+1.0) even if the changes were only editorial.
 
-   2.  An artifact author MAY skip version numbers.  That is, an
-       artifact's revision history could be 1.0.0, 1.1.0, and 1.3.0
-       where 1.2.0 is skipped.  Note that skipping versions has an
-       impact when importing modules by recommended-min.  See Section 4
-       for more details on importing modules with revision-label version
-       gaps.
+   2.  An artifact author MAY skip versions.  That is, an artifact's
+       version history could be 1.0.0, 1.1.0, and 1.3.0 where 1.2.0 is
+       skipped.
 
    Although YANG Semver always indicates when a non-backwards-
    compatible, or backwards-compatible change may have occurred to a
    YANG artifact, it does not guarantee that such a change has occurred,
    or that consumers of that YANG artifact will be impacted by the
    change.  Hence, tooling, e.g.,
-   [I-D.ietf-netmod-yang-schema-comparison] , also plays an important
+   [I-D.ietf-netmod-yang-schema-comparison], also plays an important
    role for comparing YANG artifacts and calculating the likely impact
    from changes.
+
+
+
+Clarke, et al.            Expires 26 July 2024                 [Page 11]
+
+Internet-Draft                 YANG Semver                  January 2024
+
 
    [I-D.ietf-netmod-yang-module-versioning] defines the "rev:non-
    backwards-compatible" extension statement to indicate where non-
@@ -656,29 +628,17 @@ Internet-Draft                 YANG Semver                  October 2023
    version has been incremented it does not necessarily mean that a
    "rev:non-backwards-compatible" statement would be present.
 
-3.5.  Examples of the YANG Semver Label
+3.6.  Examples of the YANG Semver Label
 
-3.5.1.  Example Module Using YANG Semver
+3.6.1.  Example Module Using YANG Semver
 
    Below is a sample YANG module that uses the YANG Semver revision-
    label based on the rules defined in this document.
-
-
-
-
-
-
-
-Clarke, et al.            Expires 4 April 2024                 [Page 12]
-
-Internet-Draft                 YANG Semver                  October 2023
-
 
      module example-versioned-module {
        yang-version 1.1;
        namespace "urn:example:versioned:module";
        prefix "exvermod";
-       rev:revision-label-scheme "ysver:yang-semver";
 
        import ietf-yang-revisions { prefix "rev"; }
        import ietf-yang-semver { prefix "ysver"; }
@@ -688,28 +648,35 @@ Internet-Draft                 YANG Semver                  October 2023
 
        revision 2017-08-30 {
          description "Backport 'wibble' leaf";
-         rev:revision-label 1.2.2_non_compatible;
+         ysver:version 1.2.2_non_compatible;
        }
 
        revision 2017-07-30 {
          description "Rename 'baz' to 'bar'";
-         rev:revision-label 1.2.1_non_compatible;
+         ysver:version 1.2.1_non_compatible;
          rev:non-backwards-compatible;
        }
 
        revision 2017-04-20 {
          description "Add new functionality, leaf 'baz'";
-         rev:revision-label 1.2.0;
+         ysver:version 1.2.0;
        }
 
        revision 2017-04-03 {
          description "Add new functionality, leaf 'foo'";
-         rev:revision-label 1.1.0;
+         ysver:version 1.1.0;
        }
+
+
+
+Clarke, et al.            Expires 26 July 2024                 [Page 12]
+
+Internet-Draft                 YANG Semver                  January 2024
+
 
        revision 2017-02-07 {
          description "First release version.";
-         rev:revision-label 1.0.0;
+         ysver:version 1.0.0;
        }
 
        // Note: YANG Semver rules do not apply to 0.X.Y labels.
@@ -721,15 +688,7 @@ Internet-Draft                 YANG Semver                  October 2023
 
        // revision 2017-01-30 {
        //   description "NBC changes to initial revision";
-       //   rev:revision-label 0.2.0;
-
-
-
-Clarke, et al.            Expires 4 April 2024                 [Page 13]
-
-Internet-Draft                 YANG Semver                  October 2023
-
-
+       //   ysver:version 0.2.0;
        //   rev:non-backwards-compatible; // optional
        //                         // (theoretically no
        //                         // 'previous released version')
@@ -737,17 +696,39 @@ Internet-Draft                 YANG Semver                  October 2023
 
        // revision 2017-01-26 {
        //   description "Initial module version";
-       //   rev:revision-label 0.1.0;
+       //   ysver:version 0.1.0;
        // }
 
        //YANG module definition starts here
      }
 
-3.5.2.  Example of Package Using YANG Semver
+3.6.2.  Example of Package Using YANG Semver
 
    Below is an example YANG package that uses the YANG Semver revision
    label based on the rules defined in this document.  Note: '\' line
-   wrapping per [RFC8792] .
+   wrapping per [RFC8792].
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Clarke, et al.            Expires 26 July 2024                 [Page 13]
+
+Internet-Draft                 YANG Semver                  January 2024
+
 
    {
      "ietf-yang-instance-data:instance-data-set": {
@@ -774,73 +755,107 @@ Internet-Draft                 YANG Semver                  October 2023
 
                                   Figure 1
 
-
-
-
-
-
-
-
-Clarke, et al.            Expires 4 April 2024                 [Page 14]
-
-Internet-Draft                 YANG Semver                  October 2023
-
-
-4.  Import Module by Semantic Version
+4.  Import Module by YANG Semantic Version
 
    [I-D.ietf-netmod-yang-module-versioning] allows for imports to be
-   done based on a module or a derived revision of a module.  The
-   rev:recommended-min statement can specify either a revision date or a
-   revision label.  The YANG Semver revision-label value can be used as
-   the argument to rev:recommended-min .  When used as such, any module
-   that contains exactly the same YANG semantic version in its revision
-   history may be used to satisfy the import requirement.  For example:
+   done based on the earliest supported date and later using the
+   rev:recommended-min-date extension.  This section defines a similar
+   extension for controlling import by YANG semantic version, as well as
+   the rules for how imports are resolved.
+
+4.1.  The recommended-min-version Extension
+
+   The ietf-yang-semver module defines a "recommended-min-version"
+   extension -- a substatement to the "import" statement -- that takes a
+   YANG semantic version as its argument and specifies that the minimum
+   version of the associated module being imported SHOULD be greater
+   than or equal to the specified value.  The specific conditions for
+   determining if a module's version is greater than or equal is defined
+   in Section 4.2 below.  Multiple recommended-min-version statements
+   MAY be specified.  If there are multiple recommended-min-version
+   statements, they are treated as a logical OR.  Removing recommended-
+   min-version statements is considered a backwards compatible change.
+   An example use is:
+
+
+
+
+
+Clarke, et al.            Expires 26 July 2024                 [Page 14]
+
+Internet-Draft                 YANG Semver                  January 2024
+
 
            import example-module {
-             rev:recommended-min 3.0.0;
+             ysver:recommended-min-version 3.0.0;
            }
 
-   Note: the import lookup does not stop when a non-backward-compatible
-   change is encountered.  That is, if module B imports a module A at or
-   derived from version 2.0.0, resolving that import will pass through a
-   revision of module A with version "2.1.0_non_compatible" in order to
-   determine if the present instance of module A derives from "2.0.0".
+4.2.  Import by YANG Semantic Version Rules
 
-   If an import by recommended-min cannot locate the specified revision-
-   label in a given module's revision history, that import will fail.
-   This is noted in the case of version gaps.  That is, if a module's
-   history includes "1.0.0", "1.1.0", and "1.3.0", an import from
-   recommended-min at "1.2.0" will be unable to locate the specified
-   revision entry and thus the import cannot be satisfied.
+   A module to be imported is considered viable with recommended-min-
+   version if it meets one of the following conditions:
+
+   1.  Has the same MAJOR and MINOR version numbers and same or greater
+       PATCH number.
+
+   2.  Has the same MAJOR version number and greater MINOR number.  In
+       this case the PATCH number is ignored.
+
+   3.  Has a greater MAJOR version number.  In this case MINOR and PATCH
+       numbers are ignored.
+
+   In all cases, the "_compatible" and "_non_compatible" version
+   modifiers are ignored.
+
+   If the recommended-min-version is specified as 3.1.0, the following
+   examples would be viable:
+
+      3.1.1 (by condition 1 above)
+
+      3.2.0 (by condition 2 above)
+
+      4.1.2 (by condition 3 above)
+
+      3.1.1_compatible (by condition 1 above, noting that modifiers are
+      ignored)
+
+      3.1.2_non_compatible (by condition 1 above, noting that modifiers
+      are ignored)
+
+   If an import by recommended-min-version cannot locate a module with a
+   version that is viable according to the conditions above, the YANG
+   compiler SHOULD emit a warning, and then continue to resolve the
+   import based on established [RFC7950] rules.
 
 5.  Guidelines for Using Semver During Module Development
 
    This section and the IETF-specific sub-section below provides YANG
    Semver-specific guidelines to consider when developing new YANG
-   modules.  As such this section updates [RFC8407] .
+   modules.  As such this section updates [RFC8407].
+
+
+
+
+
+Clarke, et al.            Expires 26 July 2024                 [Page 15]
+
+Internet-Draft                 YANG Semver                  January 2024
+
 
    Development of a brand new YANG module or submodule outside of the
-   IETF that uses YANG Semver as its revision-label scheme SHOULD begin
-   with a 0 for the MAJOR version component.  This allows the module or
+   IETF that uses the YANG Semver versioning scheme SHOULD begin with a
+   0 for the MAJOR version component.  This allows the module or
    submodule to disregard strict SemVer rules with respect to non-
    backwards-compatible changes during its initial development.
    However, module or submodule developers MAY choose to use the SemVer
-   pre-release syntax instead with a 1 for the MAJOR version component.
-   For example, an initial module or submodule revision-label might be
-   either 0.0.1 or 1.0.0-alpha.1.  If the authors choose to use the 0
-   MAJOR version component scheme, they MAY switch to the pre-release
-   scheme with a MAJOR version component of 1 when the module or
-   submodule is nearing initial release (e.g., a module's or submodule's
-   revision label may transition from 0.3.0 to 1.0.0-beta.1 to indicate
-   it is more mature and ready for testing).
-
-
-
-
-Clarke, et al.            Expires 4 April 2024                 [Page 15]
-
-Internet-Draft                 YANG Semver                  October 2023
-
+   pre-release syntax instead with a 1 for the MAJOR version number.
+   For example, an initial module or submodule version might be either
+   0.0.1 or 1.0.0-alpha.1.  If the authors choose to use the 0 MAJOR
+   version number scheme, they MAY switch to the pre-release scheme with
+   a MAJOR version number of 1 when the module or submodule is nearing
+   initial release (e.g., a module's or submodule's version may
+   transition from 0.3.0 to 1.0.0-beta.1 to indicate it is more mature
+   and ready for testing).
 
    When using pre-release notation, the format MUST include at least one
    alphabetic component and MUST end with a '.' or '-' and then one or
@@ -857,59 +872,52 @@ Internet-Draft                 YANG Semver                  October 2023
       3.0.0-202007.rc.1
 
    When developing a new revision of an existing module or submodule
-   using the YANG Semver revision-label scheme, the intended target
-   semantic version MUST be used along with pre-release notation.  For
-   example, if a released module or submodule which has a current
-   revision-label of 1.0.0 is being modified with the intent to make
-   non-backwards-compatible changes, the first development MAJOR version
-   component must be 2 with some pre-release notation such as -alpha.1,
-   making the version 2.0.0-alpha.1.  That said, every publicly
-   available release of a module or submodule MUST have a unique YANG
-   Semver revision-label (where a publicly available release is one that
-   could be implemented by a vendor or consumed by an end user).
-   Therefore, it may be prudent to include the year or year and month
-   development began (e.g., 2.0.0-201907-alpha.1).  As a module or
-   submodule undergoes development, it is possible that the original
-   intent changes.  For example, a 1.0.0 version of a module or
-   submodule that was destined to become 2.0.0 after a development cycle
-   may have had a scope change such that the final version has no non-
-   backwards-compatible changes and becomes 1.1.0 instead.  This change
-   is acceptable to make during the development phase so long as pre-
-   release notation is present in both versions (e.g., 2.0.0-alpha.3
-   becomes 1.1.0-alpha.4).  However, on the next development cycle
-   (after 1.1.0 is released), if again the new target release is 2.0.0,
-   new pre-release components must be used such that every revision-
-   label for a given module or submodule MUST be unique throughout its
-   entire lifecycle (e.g., the first pre-release version might be
-   2.0.0-202005-alpha.1 if keeping the same year and month notation
-   mentioned above).
+   using the YANG Semver versioning scheme, the intended target semantic
+   version MUST be used along with pre-release notation.  For example,
+   if a released module or submodule which has a current version of
+   1.0.0 is being modified with the intent to make non-backwards-
+   compatible changes, the first development MAJOR version component
+   must be 2 with some pre-release notation such as -alpha.1, making the
+   version 2.0.0-alpha.1.  That said, every publicly available release
+   of a module or submodule MUST have a unique YANG Semver identifier
+   (where a publicly available release is one that could be implemented
+   by a vendor or consumed by an end user).  Therefore, it may be
+   prudent to include the year or year and month development began
+   (e.g., 2.0.0-201907-alpha.1).  As a module or submodule undergoes
+   development, it is possible that the original intent changes.  For
+   example, a 1.0.0 version of a module or submodule that was destined
+   to become 2.0.0 after a development cycle may have had a scope change
+   such that the final version has no non-backwards-compatible changes
+   and becomes 1.1.0 instead.  This change is acceptable to make during
+   the development phase so long as pre-release notation is present in
 
 
 
-
-
-
-
-
-
-
-Clarke, et al.            Expires 4 April 2024                 [Page 16]
+Clarke, et al.            Expires 26 July 2024                 [Page 16]
 
-Internet-Draft                 YANG Semver                  October 2023
+Internet-Draft                 YANG Semver                  January 2024
 
+
+   both versions (e.g., 2.0.0-alpha.3 becomes 1.1.0-alpha.4).  However,
+   on the next development cycle (after 1.1.0 is released), if again the
+   new target release is 2.0.0, new pre-release components must be used
+   such that every version for a given module or submodule MUST be
+   unique throughout its entire lifecycle (e.g., the first pre-release
+   version might be 2.0.0-202005-alpha.1 if keeping the same year and
+   month notation mentioned above).
 
 5.1.  Pre-release Version Precedence
 
    As a module or submodule is developed, the scope of the work may
-   change.  That is, while a ratified module or submodule with revision-
-   label 1.0.0 is initially intended to become 2.0.0 in its next
-   ratified version, the scope of work may change such that the final
-   version is 1.1.0.  During the development cycle, the pre-release
-   versions could move from 2.0.0-some-pre-release-tag to 1.1.0-some-
-   pre-release-tag.  This downwards changing of version numbers makes it
-   difficult to evaluate semantic version rules between pre-release
-   versions.  However, taken independently, each pre-release version can
-   be compared to the previously ratified version (e.g., 1.1.0-some-pre-
+   change.  That is, while a released module or submodule with version
+   1.0.0 is initially intended to become 2.0.0 in its next released
+   version, the scope of work may change such that the final version is
+   1.1.0.  During the development cycle, the pre-release versions could
+   move from 2.0.0-some-pre-release-tag to 1.1.0-some-pre-release-tag.
+   This downwards changing of version identifiers makes it difficult to
+   evaluate semantic version rules between pre-release versions.
+   However, taken independently, each pre-release version can be
+   compared to the previously ratified version (e.g., 1.1.0-some-pre-
    release-tag and 2.0.0-some-pre-release-tag can each be compared to
    1.0.0).  Module and submodule developers SHOULD maintain only one
    revision statement in a pre-released module or submodule that
@@ -920,24 +928,32 @@ Internet-Draft                 YANG Semver                  October 2023
 5.2.  YANG Semver in IETF Modules
 
    All published IETF modules and submodules MUST use YANG semantic
-   versions for their revision-labels.
+   versions in their revisions.
 
    Development of a new module or submodule within the IETF SHOULD begin
    with the 0 MAJOR number scheme as described above.  When revising an
-   existing IETF module or submodule, the revision-label MUST use the
-   target (i.e., intended) MAJOR and MINOR version components with a 0
-   PATCH version component.  If the intended ratified release will be
-   non-backward-compatible with the current ratified release, the MINOR
-   version component MUST be 0.
+   existing IETF module or submodule, the version MUST use the target
+   (i.e., intended) MAJOR and MINOR version components with a 0 PATCH
+   version number.  If the intended RFC release will be non-backwards-
+   compatible with the current RFC release, the MINOR version number
+   MUST be 0.
 
 5.2.1.  Guidelines for IETF Module Development
 
    All IETF modules and submodules in development MUST use the whole
-   document name as a pre-release version string, including the current
-   document revision.  For example, if a module or submodule which is
-   currently released at version 1.0.0 is being revised to include non-
-   backwards-compatible changes in draft-user-netmod-foo, its
-   development revision-labels MUST include 2.0.0-draft-user-netmod-foo
+   document name as a pre-release version identifier, including the
+   current document revision.  For example, if a module or submodule
+   which is currently released at version 1.0.0 is being revised to
+   include non-backwards-compatible changes in draft-user-netmod-foo,
+   its development versions MUST include 2.0.0-draft-user-netmod-foo
+
+
+
+Clarke, et al.            Expires 26 July 2024                 [Page 17]
+
+Internet-Draft                 YANG Semver                  January 2024
+
+
    followed by the document's revision (e.g., 2.0.0-draft-user-netmod-
    foo-02).  This will ensure each pre-release version is unique across
    the lifecycle of the module or submodule.  Even when using the 0
@@ -945,14 +961,6 @@ Internet-Draft                 YANG Semver                  October 2023
    MINOR and PATCH can change), appending the draft name as a pre-
    release component helps to ensure uniqueness when there are perhaps
    multiple, parallel efforts creating the same module or submodule.
-
-
-
-
-Clarke, et al.            Expires 4 April 2024                 [Page 17]
-
-Internet-Draft                 YANG Semver                  October 2023
-
 
    Some draft revisions may not include an update to the YANG modules or
    submodules contained in the draft.  In that case, those modules or
@@ -965,32 +973,27 @@ Internet-Draft                 YANG Semver                  October 2023
 5.2.2.  Guidelines for Published IETF Modules
 
    For IETF YANG modules and submodules that have already been
-   published, revision-labels MUST be retroactively applied to all
-   existing revisions when the next new revision is created, starting at
-   version "1.0.0" for the initial published revision, and then
-   incrementing according to the YANG Semver version rules specified in
-   Section 3.4 . For example, if a module or submodule started out in
-   the pre-NMDA ([RFC8342] ) world, and then had NMDA support added
-   without removing any legacy "state" branches -- and you are looking
-   to add additional new features -- a sensible choice for the target
-   YANG Semver would be 1.2.0 (since 1.0.0 would have been the initial,
-   pre-NMDA release, and 1.1.0 would have been the NMDA revision).
+   published, versions MUST be retroactively applied to all existing
+   revisions when the next new revision is created, starting at version
+   "1.0.0" for the initial published revision, and then incrementing
+   according to the YANG Semver version rules specified in Section 3.5.
+   For example, if a module or submodule started out in the pre-NMDA
+   ([RFC8342] ) world, and then had NMDA support added without removing
+   any legacy "state" branches -- and you are looking to add additional
+   new features -- a sensible choice for the target YANG Semver would be
+   1.2.0 (since 1.0.0 would have been the initial, pre-NMDA release, and
+   1.1.0 would have been the NMDA revision).
 
 6.  YANG Module
 
    This YANG module contains the typedef for the YANG semantic version
    and the identity to signal its use.
 
-   <CODE BEGINS> file "ietf-yang-semver@2023-01-17.yang"
+   <CODE BEGINS> file "ietf-yang-semver@2024-01-22.yang"
    module ietf-yang-semver {
      yang-version 1.1;
      namespace "urn:ietf:params:xml:ns:yang:ietf-yang-semver";
      prefix ysver;
-     rev:revision-label-scheme "yang-semver";
-
-     import ietf-yang-revisions {
-       prefix rev;
-     }
 
      organization
        "IETF NETMOD (Network Modeling) Working Group";
@@ -999,17 +1002,17 @@ Internet-Draft                 YANG Semver                  October 2023
         WG List:  <mailto:netmod@ietf.org>
 
         Author:   Joe Clarke
+
+
+
+Clarke, et al.            Expires 26 July 2024                 [Page 18]
+
+Internet-Draft                 YANG Semver                  January 2024
+
+
                   <mailto:jclarke@cisco.com>
         Author:   Robert Wilton
                   <mailto:rwilton@cisco.com>
-
-
-
-Clarke, et al.            Expires 4 April 2024                 [Page 18]
-
-Internet-Draft                 YANG Semver                  October 2023
-
-
         Author:   Reshad Rahman
                   <mailto:reshad@yahoo.com>
         Author:   Balazs Lengyel
@@ -1022,7 +1025,7 @@ Internet-Draft                 YANG Semver                  October 2023
        "This module provides type and grouping definitions for YANG
         packages.
 
-        Copyright (c) 2022 IETF Trust and the persons identified as
+        Copyright (c) 2024 IETF Trust and the persons identified as
         authors of the code.  All rights reserved.
 
         Redistribution and use in source and binary forms, with or
@@ -1041,8 +1044,8 @@ Internet-Draft                 YANG Semver                  October 2023
      // note.
      // RFC Ed. update the rev:revision-label to "1.0.0".
 
-     revision 2023-01-17 {
-       rev:label "1.0.0-draft-ietf-netmod-yang-semver-10";
+     revision 2024-01-22 {
+       ysver:version "1.0.0-draft-ietf-netmod-yang-semver-13";
        description
          "Initial revision";
        reference
@@ -1050,26 +1053,89 @@ Internet-Draft                 YANG Semver                  October 2023
      }
 
      /*
-      * Identities
+      * Extensions
       */
 
-     identity yang-semver {
-       base rev:revision-label-scheme-base;
-       description
-         "The revision-label scheme corresponds to the YANG Semver
-          scheme which is defined by the pattern in the 'version'
+     extension version {
+       argument yang-semantic-version;
 
 
 
-Clarke, et al.            Expires 4 April 2024                 [Page 19]
+Clarke, et al.            Expires 26 July 2024                 [Page 19]
 
-Internet-Draft                 YANG Semver                  October 2023
+Internet-Draft                 YANG Semver                  January 2024
 
 
-          typedef below. The rules governing this revision-label
-          scheme are defined in the reference for this identity.";
+       description
+         "The version can be used to provide an additional
+          identifier associated with a module or submodule
+          revision.
+
+          The format of the revision label argument MUST conform to the
+          'version' typedef defined in this module.
+
+          The statement MUST only be a substatement of the revision
+          statement.  Zero or one revision label statements per parent
+          statement are allowed.  No substatements for this extension
+          have been standardized.
+
+          Versions MUST be unique amongst all revisions of a
+          module or submodule.
+
+          Adding a version is a backwards-compatible
+          change.  Changing or removing an existing version in
+          the revision history is a non-backwards-compatible
+          change, because it could impact any references to that
+          version.";
        reference
-         "RFC XXXX: YANG Semantic Versioning.";
+         "XXXX: YANG Semantic Versioning;
+          Section 3.2, YANG Semantic Version Extension";
+     }
+
+     extension recommended-min-version {
+       argument yang-semantic-version;
+       description
+         "Recommends the versions of the module that may be imported to
+          one that is greater than or equal to the specified version.
+
+          The argument value MUST conform to the
+          'version' typedef defined in this module.
+
+          The statement MUST only be a substatement of the import
+          statement.  Zero, one or more 'recommended-min-version'
+          statements per parent statement are allowed.  No
+          substatements for this extension have been
+          standardized.
+
+          If specified multiple times, then any module revision that
+          satisfies at least one of the 'recommended-min-version'
+          statements is an acceptable recommended version for
+          import.
+
+          A particular version of an imported module adheres to an
+          import's 'recommended-min-version' extension statement if one
+
+
+
+Clarke, et al.            Expires 26 July 2024                 [Page 20]
+
+Internet-Draft                 YANG Semver                  January 2024
+
+
+          of the following conditions are met:
+
+          * Has the same MAJOR and MINOR version numbers and same or
+            greater PATCH number.
+          * Has the same MAJOR version number and greater MINOR number.
+            In this case the PATCH number is ignored.
+          * Has a greater MAJOR version number.  In this case
+            MINOR and PATCH numbers are ignored.
+
+          Adding, removing or updating a 'recommended-min-version'
+          statement to an import is a backwards-compatible change.";
+       reference
+         "XXXX: YANG Semantic Versioning; Section 4,
+          Import Module by Semantic Version";
      }
 
      /*
@@ -1077,7 +1143,7 @@ Internet-Draft                 YANG Semver                  October 2023
       */
 
      typedef version {
-       type rev:revision-label {
+       type string {
          pattern '[0-9]+[.][0-9]+[.][0-9]+(_(non_)?compatible)?'
                + '(-[A-Za-z0-9.-]+[.-][0-9]+)?([+][A-Za-z0-9.-]+)?';
        }
@@ -1104,6 +1170,14 @@ Internet-Draft                 YANG Semver                  October 2023
 
                                   Figure 2
 
+
+
+
+Clarke, et al.            Expires 26 July 2024                 [Page 21]
+
+Internet-Draft                 YANG Semver                  January 2024
+
+
 8.  Acknowledgments
 
    This document grew out of the YANG module versioning design team that
@@ -1114,21 +1188,13 @@ Internet-Draft                 YANG Semver                  October 2023
    (Wangzitao), Per Andersson, Qin Wu, Reshad Rahman, Tom Hill, and Rob
    Wilton.
 
-
-
-
-Clarke, et al.            Expires 4 April 2024                 [Page 20]
-
-Internet-Draft                 YANG Semver                  October 2023
-
-
    The initial revision of this document was refactored and built upon
-   [I-D.clacla-netmod-yang-model-update] .  We would like the thank
-   Kevin D'Souza for his initial work in this problem space.
+   [I-D.clacla-netmod-yang-model-update].  We would like the thank Kevin
+   D'Souza for his initial work in this problem space.
 
    Discussions on the use of SemVer for YANG versioning has been held
    with authors of the OpenConfig YANG models based on their own
-   [openconfigsemver] .  We would like thank both Anees Shaikh and Rob
+   [openconfigsemver].  We would like thank both Anees Shaikh and Rob
    Shakir for their input into this problem space.
 
    We would also like to thank Joseph Donahue from the SemVer.org
@@ -1138,11 +1204,11 @@ Internet-Draft                 YANG Semver                  October 2023
 
    The YANG module specified in this document defines a schema for data
    that is designed to be accessed via network management protocols such
-   as NETCONF [RFC6241] or RESTCONF [RFC8040] .  The lowest NETCONF
-   layer is the secure transport layer, and the mandatory-to-implement
-   secure transport is Secure Shell (SSH) [RFC6242] .  The lowest
-   RESTCONF layer is HTTPS, and the mandatory-to-implement secure
-   transport is TLS [RFC8446] .
+   as NETCONF [RFC6241] or RESTCONF [RFC8040].  The lowest NETCONF layer
+   is the secure transport layer, and the mandatory-to-implement secure
+   transport is Secure Shell (SSH) [RFC6242].  The lowest RESTCONF layer
+   is HTTPS, and the mandatory-to-implement secure transport is TLS
+   [RFC8446].
 
    The NETCONF access control model [RFC8341] provides the means to
    restrict access for particular NETCONF or RESTCONF users to a
@@ -1150,17 +1216,23 @@ Internet-Draft                 YANG Semver                  October 2023
    operations and content.
 
    That said, the YANG module in this document does not define any
-   schema nodes (i.e., nothing that can be read or written).  It only
-   defines a typedef and an identity.  Therefore, there is no need to
-   further protect any nodes with access control.
+   writeable nodes.  The extensions defined are only used to document
+   YANG artifacts.
 
 10.  IANA Considerations
 
 10.1.  YANG Module Registrations
 
    This document requests IANA to register a URI in the "IETF XML
-   Registry" [RFC3688] .  Following the format in RFC 3688, the
-   following registration is requested.
+   Registry" [RFC3688].  Following the format in RFC 3688, the following
+   registration is requested.
+
+
+
+Clarke, et al.            Expires 26 July 2024                 [Page 22]
+
+Internet-Draft                 YANG Semver                  January 2024
+
 
       URI: urn:ietf:params:xml:ns:yang:ietf-yang-semver
 
@@ -1168,18 +1240,8 @@ Internet-Draft                 YANG Semver                  October 2023
 
       XML: N/A, the requested URI is an XML namespace.
 
-
-
-
-
-
-Clarke, et al.            Expires 4 April 2024                 [Page 21]
-
-Internet-Draft                 YANG Semver                  October 2023
-
-
    The following YANG module is requested to be registered in the "IANA
-   Module Names" [RFC6020] .  Following the format in RFC 6020, the
+   Module Names" [RFC6020].  Following the format in RFC 6020, the
    following registrations are requested:
 
    The ietf-yang-semver module:
@@ -1201,38 +1263,38 @@ Internet-Draft                 YANG Semver                  October 2023
 
    IANA is responsible for maintaining and versioning some YANG modules
    and submodules, e.g., iana-if-types.yang [IfTypeYang] and iana-
-   routing-types.yang [RoutingTypesYang] .
+   routing-types.yang [RoutingTypesYang].
 
    In addition to following the rules specified in the IANA
-   Considerations section of [I-D.ietf-netmod-yang-module-versioning] ,
+   Considerations section of [I-D.ietf-netmod-yang-module-versioning],
    IANA maintained YANG modules and submodules MUST also include a YANG
-   Semver revision label for all new revisions, as defined in Section 3
-   .
+   Semver revision label for all new revisions, as defined in Section 3.
 
    The YANG Semver version associated with the new revision MUST follow
-   the rules defined in Section 3.4 .
+   the rules defined in Section 3.5.
 
    Note: For IANA maintained YANG modules and submodules that have
-   already been published, revision labels MUST be retroactively applied
-   to all existing revisions when the next new revision is created,
-   starting at version "1.0.0" for the initial published revision, and
-   then incrementing according to the YANG Semver rules specified in
-   Section 3.4 .
+   already been published, versions MUST be retroactively applied to all
+   existing revisions when the next new revision is created, starting at
+   version "1.0.0" for the initial published revision, and then
+   incrementing according to the YANG Semver rules specified in
+   Section 3.5.
+
+
+
+
+
+
+Clarke, et al.            Expires 26 July 2024                 [Page 23]
+
+Internet-Draft                 YANG Semver                  January 2024
+
 
    Most changes to IANA maintained YANG modules and submodules are
    expected to be backwards-compatible changes and classified as MINOR
    version changes.  The PATCH version may be incremented instead when
    only editorial changes are made, and the MAJOR version would be
    incremented if non-backwards-compatible changes are made.
-
-
-
-
-
-Clarke, et al.            Expires 4 April 2024                 [Page 22]
-
-Internet-Draft                 YANG Semver                  October 2023
-
 
    Given that IANA maintained YANG modules are versioned with a linear
    history, it is anticipated that it should not be necessary to use the
@@ -1266,13 +1328,31 @@ Internet-Draft                 YANG Semver                  October 2023
               DOI 10.17487/RFC8407, October 2018,
               <https://www.rfc-editor.org/info/rfc8407>.
 
+   [RFC7950]  Bjorklund, M., Ed., "The YANG 1.1 Data Modeling Language",
+              RFC 7950, DOI 10.17487/RFC7950, August 2016,
+              <https://www.rfc-editor.org/info/rfc7950>.
+
+
+
+
+
+
+
+
+
+
+Clarke, et al.            Expires 26 July 2024                 [Page 24]
+
+Internet-Draft                 YANG Semver                  January 2024
+
+
    [I-D.ietf-netmod-yang-module-versioning]
               Wilton, R., Rahman, R., Lengyel, B., Clarke, J., and J.
               Sterne, "Updated YANG Module Revision Handling", Work in
               Progress, Internet-Draft, draft-ietf-netmod-yang-module-
-              versioning-09, 17 April 2023,
+              versioning-10, 17 October 2023,
               <https://datatracker.ietf.org/doc/html/draft-ietf-netmod-
-              yang-module-versioning-09>.
+              yang-module-versioning-10>.
 
 11.2.  Informative References
 
@@ -1282,13 +1362,6 @@ Internet-Draft                 YANG Semver                  October 2023
               Draft, draft-clacla-netmod-yang-model-update-06, 2 July
               2018, <https://datatracker.ietf.org/doc/html/draft-clacla-
               netmod-yang-model-update-06>.
-
-
-
-Clarke, et al.            Expires 4 April 2024                 [Page 23]
-
-Internet-Draft                 YANG Semver                  October 2023
-
 
    [I-D.ietf-netmod-yang-packages]
               Wilton, R., Rahman, R., Clarke, J., Sterne, J., and B. Wu,
@@ -1322,6 +1395,13 @@ Internet-Draft                 YANG Semver                  October 2023
               Protocol", RFC 8040, DOI 10.17487/RFC8040, January 2017,
               <https://www.rfc-editor.org/info/rfc8040>.
 
+
+
+Clarke, et al.            Expires 26 July 2024                 [Page 25]
+
+Internet-Draft                 YANG Semver                  January 2024
+
+
    [RFC8341]  Bierman, A. and M. Bjorklund, "Network Configuration
               Access Control Model", STD 91, RFC 8341,
               DOI 10.17487/RFC8341, March 2018,
@@ -1335,16 +1415,6 @@ Internet-Draft                 YANG Semver                  October 2023
               "Handling Long Lines in Content of Internet-Drafts and
               RFCs", RFC 8792, DOI 10.17487/RFC8792, June 2020,
               <https://www.rfc-editor.org/info/rfc8792>.
-
-
-
-
-
-
-Clarke, et al.            Expires 4 April 2024                 [Page 24]
-
-Internet-Draft                 YANG Semver                  October 2023
-
 
    [openconfigsemver]
               "Semantic Versioning for Openconfig Models",
@@ -1374,6 +1444,20 @@ Appendix A.  Example IETF Module Development
 
    Version lineage for initial module development:
 
+
+
+
+
+
+
+
+
+
+Clarke, et al.            Expires 26 July 2024                 [Page 26]
+
+Internet-Draft                 YANG Semver                  January 2024
+
+
          0.0.1-draft-jdoe-netmod-example-module-00
            |
          0.1.0-draft-jdoe-netmod-example-module-01
@@ -1386,7 +1470,7 @@ Appendix A.  Example IETF Module Development
    draft.  Thus now the draft becomes draft-ietf-netmod-example-module.
    The initial pre-release lineage continues as follows.
 
-   Continued version lineage after adoption:
+   Continued version progression after adoption:
 
        1.0.0-draft-ietf-netmod-example-module-00
          |
@@ -1394,15 +1478,7 @@ Appendix A.  Example IETF Module Development
          |
        1.0.0-draft-ietf-netmod-example-module-02
 
-
-
-
-Clarke, et al.            Expires 4 April 2024                 [Page 25]
-
-Internet-Draft                 YANG Semver                  October 2023
-
-
-   At this point, the draft is ratified and becomes RFC12345 and the
+   At this point, the draft is standardized and becomes RFC12345 and the
    YANG module version becomes 1.0.0.
 
    A time later, the module needs to be revised to add additional
@@ -1426,7 +1502,17 @@ Internet-Draft                 YANG Semver                  October 2023
 
    At this point, the WG decides to merge some aspects of both and adopt
    the work in asmith's draft as draft-ietf-netmod-exmod-changes.  A
-   single version lineage continues.
+   single version progression continues.
+
+
+
+
+
+
+Clarke, et al.            Expires 26 July 2024                 [Page 27]
+
+Internet-Draft                 YANG Semver                  January 2024
+
 
          1.1.0-draft-ietf-netmod-exmod-changes-00
            |
@@ -1436,7 +1522,7 @@ Internet-Draft                 YANG Semver                  October 2023
            |
          1.1.0-draft-ietf-netmod-exmod-changes-03
 
-   The draft is ratified, and the new module version becomes 1.1.0.
+   The draft is standardized, and the new module version becomes 1.1.0.
 
 Authors' Addresses
 
@@ -1447,15 +1533,6 @@ Authors' Addresses
    United States of America
    Phone: +1-919-392-2867
    Email: jclarke@cisco.com
-
-
-
-
-
-
-Clarke, et al.            Expires 4 April 2024                 [Page 26]
-
-Internet-Draft                 YANG Semver                  October 2023
 
 
    Robert Wilton (editor)
@@ -1488,25 +1565,4 @@ Internet-Draft                 YANG Semver                  October 2023
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Clarke, et al.            Expires 4 April 2024                 [Page 27]
+Clarke, et al.            Expires 26 July 2024                 [Page 28]

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -6,14 +6,14 @@ Network Working Group                                     J. Clarke, Ed.
 Internet-Draft                                            R. Wilton, Ed.
 Updates: 8407, 8525, 7950 (if approved)              Cisco Systems, Inc.
 Intended status: Standards Track                               R. Rahman
-Expires: 13 September 2024                                       Equinix
+Expires: 16 September 2024                                       Equinix
                                                               B. Lengyel
                                                                 Ericsson
                                                                J. Sterne
                                                                    Nokia
                                                                B. Claise
                                                                   Huawei
-                                                           12 March 2024
+                                                           15 March 2024
 
 
                         YANG Semantic Versioning
@@ -43,7 +43,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 13 September 2024.
+   This Internet-Draft will expire on 16 September 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Clarke, et al.          Expires 13 September 2024               [Page 1]
+Clarke, et al.          Expires 16 September 2024               [Page 1]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Clarke, et al.          Expires 13 September 2024               [Page 2]
+Clarke, et al.          Expires 16 September 2024               [Page 2]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -165,7 +165,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024               [Page 3]
+Clarke, et al.          Expires 16 September 2024               [Page 3]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -221,7 +221,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024               [Page 4]
+Clarke, et al.          Expires 16 September 2024               [Page 4]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -277,7 +277,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024               [Page 5]
+Clarke, et al.          Expires 16 September 2024               [Page 5]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -333,7 +333,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024               [Page 6]
+Clarke, et al.          Expires 16 September 2024               [Page 6]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -389,7 +389,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024               [Page 7]
+Clarke, et al.          Expires 16 September 2024               [Page 7]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -445,7 +445,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024               [Page 8]
+Clarke, et al.          Expires 16 September 2024               [Page 8]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -501,7 +501,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024               [Page 9]
+Clarke, et al.          Expires 16 September 2024               [Page 9]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -557,7 +557,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 10]
+Clarke, et al.          Expires 16 September 2024              [Page 10]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -613,7 +613,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 11]
+Clarke, et al.          Expires 16 September 2024              [Page 11]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -669,7 +669,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 12]
+Clarke, et al.          Expires 16 September 2024              [Page 12]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -725,7 +725,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 13]
+Clarke, et al.          Expires 16 September 2024              [Page 13]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -781,7 +781,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 14]
+Clarke, et al.          Expires 16 September 2024              [Page 14]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -837,7 +837,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 15]
+Clarke, et al.          Expires 16 September 2024              [Page 15]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -848,14 +848,15 @@ Internet-Draft                 YANG Semver                    March 2024
 
 5.2.  Import by YANG Semantic Version Rules
 
-   A module to be imported is considered viable with recommended-min-
-   version if it meets one of the following conditions:
+   A module to be imported is considered as meeting the recommended
+   minimum version criteria if it meets one of the following
+   conditions::
 
-   1.  Has the exact MAJOR, MINOR, PATCH and "_compatible" and
+   1.  Has the exact MAJOR, MINOR, PATCH and "_compatible" or
        "_non_compatible" modifiers as in the recommend-min-version
        value.
 
-   2.  Has the same MAJOR and MINOR version numbers a greater PATCH
+   2.  Has the same MAJOR and MINOR version numbers and a greater PATCH
        number.  In this case, "_compatible" and "_non_compatible
        modifiers" are ignored.
 
@@ -868,7 +869,7 @@ Internet-Draft                 YANG Semver                    March 2024
        ignored.
 
    If the recommended-min-version is specified as 3.1.0, the following
-   examples would be viable:
+   examples would be satisfy that recommend-min-version:
 
       3.1.0 (by condition 1 above)
 
@@ -892,8 +893,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-
-Clarke, et al.          Expires 13 September 2024              [Page 16]
+Clarke, et al.          Expires 16 September 2024              [Page 16]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -949,7 +949,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 17]
+Clarke, et al.          Expires 16 September 2024              [Page 17]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1005,7 +1005,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 18]
+Clarke, et al.          Expires 16 September 2024              [Page 18]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1061,7 +1061,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 19]
+Clarke, et al.          Expires 16 September 2024              [Page 19]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1117,7 +1117,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 20]
+Clarke, et al.          Expires 16 September 2024              [Page 20]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1173,7 +1173,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 21]
+Clarke, et al.          Expires 16 September 2024              [Page 21]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1229,7 +1229,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 22]
+Clarke, et al.          Expires 16 September 2024              [Page 22]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1285,7 +1285,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 23]
+Clarke, et al.          Expires 16 September 2024              [Page 23]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1341,7 +1341,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 24]
+Clarke, et al.          Expires 16 September 2024              [Page 24]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1397,7 +1397,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 25]
+Clarke, et al.          Expires 16 September 2024              [Page 25]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1453,7 +1453,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 26]
+Clarke, et al.          Expires 16 September 2024              [Page 26]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1509,7 +1509,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 27]
+Clarke, et al.          Expires 16 September 2024              [Page 27]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1565,7 +1565,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 28]
+Clarke, et al.          Expires 16 September 2024              [Page 28]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1621,7 +1621,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 29]
+Clarke, et al.          Expires 16 September 2024              [Page 29]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1658,8 +1658,8 @@ Internet-Draft                 YANG Semver                    March 2024
               Sterne, "Updated YANG Module Revision Handling", Work in
               Progress, Internet-Draft, draft-ietf-netmod-yang-module-
               versioning-11, 1 March 2024,
-              <https://datatracker.ietf.org/api/v1/doc/document/draft-
-              ietf-netmod-yang-module-versioning/>.
+              <https://datatracker.ietf.org/doc/html/draft-ietf-netmod-
+              yang-module-versioning-11>.
 
 13.2.  Informative References
 
@@ -1677,7 +1677,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 30]
+Clarke, et al.          Expires 16 September 2024              [Page 30]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1733,7 +1733,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 31]
+Clarke, et al.          Expires 16 September 2024              [Page 31]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1789,7 +1789,7 @@ Appendix A.  Example IETF Module Development
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 32]
+Clarke, et al.          Expires 16 September 2024              [Page 32]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1845,7 +1845,7 @@ Authors' Addresses
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 33]
+Clarke, et al.          Expires 16 September 2024              [Page 33]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1901,4 +1901,4 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 13 September 2024              [Page 34]
+Clarke, et al.          Expires 16 September 2024              [Page 34]

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -70,42 +70,42 @@ Internet-Draft                 YANG Semver                 February 2024
 Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
-   2.  Terminology and Conventions . . . . . . . . . . . . . . . . .   3
-   3.  YANG Semantic Versioning  . . . . . . . . . . . . . . . . . .   4
-     3.1.  Relationship Between SemVer and YANG Semver . . . . . . .   4
-     3.2.  YANG Semantic Version Extension . . . . . . . . . . . . .   4
-     3.3.  YANG Semver Pattern . . . . . . . . . . . . . . . . . . .   4
-     3.4.  Semantic Versioning Scheme for YANG Artifacts . . . . . .   5
-       3.4.1.  Branching Limitations with YANG Semver  . . . . . . .   7
-       3.4.2.  YANG Semver with submodules . . . . . . . . . . . . .   8
-       3.4.3.  Examples for YANG semantic versions . . . . . . . . .   8
-     3.5.  YANG Semantic Version Update Rules  . . . . . . . . . . .  10
-     3.6.  Examples of the YANG Semver Label . . . . . . . . . . . .  12
-       3.6.1.  Example Module Using YANG Semver  . . . . . . . . . .  12
-       3.6.2.  Example of Package Using YANG Semver  . . . . . . . .  13
-   4.  Import Module by YANG Semantic Version  . . . . . . . . . . .  14
-     4.1.  The recommended-min-version Extension . . . . . . . . . .  14
-     4.2.  Import by YANG Semantic Version Rules . . . . . . . . . .  15
-   5.  Guidelines for Using Semver During Module Development . . . .  15
-     5.1.  Pre-release Version Precedence  . . . . . . . . . . . . .  17
-     5.2.  YANG Semver in IETF Modules . . . . . . . . . . . . . . .  17
-       5.2.1.  Guidelines for IETF Module Development  . . . . . . .  17
-       5.2.2.  Guidelines for Published IETF Modules . . . . . . . .  18
-   6.  YANG Module . . . . . . . . . . . . . . . . . . . . . . . . .  18
-   7.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  21
-   8.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  22
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  22
-   10. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  23
-     10.1.  YANG Module Registrations  . . . . . . . . . . . . . . .  23
-     10.2.  Guidance for YANG Semver in IANA maintained YANG modules
-            and submodules . . . . . . . . . . . . . . . . . . . . .  23
-   11. References  . . . . . . . . . . . . . . . . . . . . . . . . .  24
-     11.1.  Normative References . . . . . . . . . . . . . . . . . .  24
-     11.2.  Informative References . . . . . . . . . . . . . . . . .  25
-   Appendix A.  Example IETF Module Development  . . . . . . . . . .  26
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  28
-
-
+   2.  Examples of How Versioning Is Applied To YANG Module
+           Revisions . . . . . . . . . . . . . . . . . . . . . . . .   3
+   3.  Terminology and Conventions . . . . . . . . . . . . . . . . .   4
+   4.  YANG Semantic Versioning  . . . . . . . . . . . . . . . . . .   4
+     4.1.  Relationship Between SemVer and YANG Semver . . . . . . .   4
+     4.2.  YANG Semantic Version Extension . . . . . . . . . . . . .   5
+     4.3.  YANG Semver Pattern . . . . . . . . . . . . . . . . . . .   5
+     4.4.  Semantic Versioning Scheme for YANG Artifacts . . . . . .   6
+       4.4.1.  Branching Limitations with YANG Semver  . . . . . . .   8
+       4.4.2.  YANG Semver with submodules . . . . . . . . . . . . .   9
+       4.4.3.  Examples for YANG semantic versions . . . . . . . . .   9
+     4.5.  YANG Semantic Version Update Rules  . . . . . . . . . . .  11
+     4.6.  Examples of the YANG Semver Label . . . . . . . . . . . .  13
+       4.6.1.  Example Module Using YANG Semver  . . . . . . . . . .  13
+       4.6.2.  Example of Package Using YANG Semver  . . . . . . . .  14
+   5.  Import Module by YANG Semantic Version  . . . . . . . . . . .  15
+     5.1.  The recommended-min-version Extension . . . . . . . . . .  15
+     5.2.  Import by YANG Semantic Version Rules . . . . . . . . . .  16
+   6.  Guidelines for Using Semver During Module Development . . . .  16
+     6.1.  Pre-release Version Precedence  . . . . . . . . . . . . .  18
+     6.2.  YANG Semver in IETF Modules . . . . . . . . . . . . . . .  18
+       6.2.1.  Guidelines for IETF Module Development  . . . . . . .  18
+       6.2.2.  Guidelines for Published IETF Modules . . . . . . . .  19
+   7.  YANG Module . . . . . . . . . . . . . . . . . . . . . . . . .  19
+   8.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  22
+   9.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  23
+   10. Security Considerations . . . . . . . . . . . . . . . . . . .  23
+   11. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  24
+     11.1.  YANG Module Registrations  . . . . . . . . . . . . . . .  24
+     11.2.  Guidance for YANG Semver in IANA maintained YANG modules
+            and submodules . . . . . . . . . . . . . . . . . . . . .  24
+   12. References  . . . . . . . . . . . . . . . . . . . . . . . . .  25
+     12.1.  Normative References . . . . . . . . . . . . . . . . . .  25
+     12.2.  Informative References . . . . . . . . . . . . . . . . .  26
+   Appendix A.  Example IETF Module Development  . . . . . . . . . .  27
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  29
 
 
 
@@ -140,7 +140,40 @@ Internet-Draft                 YANG Semver                 February 2024
    over time without any change to the semantic version itself.  In some
    cases the text has changed in non-backwards-compatible ways.
 
-2.  Terminology and Conventions
+2.  Examples of How Versioning Is Applied To YANG Module Revisions
+
+   The following diagram illustrates how the branched revision history
+   and the YANG Semver version extension statement could be used:
+
+   Example YANG module with branched revision history.
+
+          Module revision date        Version Identifier
+            2019-01-01                 <- 1.0.0
+                |
+            2019-02-01                 <- 2.0.0
+                |      \
+            2019-03-01  \              <- 3.0.0
+                |        \
+                |       2019-04-01     <- 2.1.0
+                |           |
+                |       2019-05-01     <- 2.2.0
+                |
+            2019-06-01                 <- 3.1.0
+
+                                  Figure 1
+
+
+
+
+Clarke, et al.           Expires 23 August 2024                 [Page 3]
+
+Internet-Draft                 YANG Semver                 February 2024
+
+
+   The tree diagram above illustrates how an example module's revision
+   history might evolve, over time.
+
+3.  Terminology and Conventions
 
    The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
@@ -163,21 +196,14 @@ Internet-Draft                 YANG Semver                 February 2024
       extended set of semantic versioning rules, based on [SemVer],
       defined within this document.
 
-
-
-Clarke, et al.           Expires 23 August 2024                 [Page 3]
-
-Internet-Draft                 YANG Semver                 February 2024
-
-
-3.  YANG Semantic Versioning
+4.  YANG Semantic Versioning
 
    This section defines YANG Semantic Versioning, explains how it is
    used with YANG artifacts, and describes the rules associated with
    changing an artifact's semantic version when its contents are
    updated.
 
-3.1.  Relationship Between SemVer and YANG Semver
+4.1.  Relationship Between SemVer and YANG Semver
 
    [SemVer] is completely compatible with YANG Semver in that a SemVer
    semantic version number is legal according to the YANG Semver rules
@@ -187,7 +213,20 @@ Internet-Draft                 YANG Semver                 February 2024
    you do not use the compatibility modifiers described below), the YANG
    Semver version label will appear as a SemVer version number.
 
-3.2.  YANG Semantic Version Extension
+
+
+
+
+
+
+
+
+Clarke, et al.           Expires 23 August 2024                 [Page 4]
+
+Internet-Draft                 YANG Semver                 February 2024
+
+
+4.2.  YANG Semantic Version Extension
 
    The ietf-yang-semver module defines a "version" extension -- a
    substatement to a module or submodule's "import" statement -- that
@@ -196,7 +235,7 @@ Internet-Draft                 YANG Semver                 February 2024
    semantic version is defined in a typedef in the same module and
    described below.
 
-3.3.  YANG Semver Pattern
+4.3.  YANG Semver Pattern
 
    YANG artifacts that employ semantic versioning as defined in this
    document MUST use a version identifier that corresponds to the
@@ -218,20 +257,12 @@ Internet-Draft                 YANG Semver                 February 2024
    Additionally, [SemVer] defines two specific types of metadata that
    may be appended to a semantic version string.  Pre-release metadata
    MAY be appended to a YANG Semver string after a trailing '-'
-
-
-
-Clarke, et al.           Expires 23 August 2024                 [Page 4]
-
-Internet-Draft                 YANG Semver                 February 2024
-
-
    character.  Build metadata MAY be appended after a trailing '+'
    character.  If both pre-release and build metadata are present, then
    build metadata MUST follow pre-release metadata.  While build
    metadata MUST be ignored when comparing YANG semantic versions, pre-
    release metadata MUST be used during module and submodule development
-   as specified in Section 5.  Both pre-release and build metadata are
+   as specified in Section 6.  Both pre-release and build metadata are
    allowed in order to support all the [SemVer] rules.  Thus, a version
    lineage that follows strict [SemVer] rules is allowed for a YANG
    artifact.
@@ -241,7 +272,17 @@ Internet-Draft                 YANG Semver                 February 2024
    well as a typedef that formally specifies the syntax of the YANG
    Semver.
 
-3.4.  Semantic Versioning Scheme for YANG Artifacts
+
+
+
+
+
+Clarke, et al.           Expires 23 August 2024                 [Page 5]
+
+Internet-Draft                 YANG Semver                 February 2024
+
+
+4.4.  Semantic Versioning Scheme for YANG Artifacts
 
    This document defines the YANG semantic versioning scheme that is
    used for YANG artifacts.  The versioning identifier has the following
@@ -274,14 +315,6 @@ Internet-Draft                 YANG Semver                 February 2024
    versioning scheme specifies the module's or submodule's semantic
    version as the argument to the 'ys:version' statement.
 
-
-
-
-Clarke, et al.           Expires 23 August 2024                 [Page 5]
-
-Internet-Draft                 YANG Semver                 February 2024
-
-
    Because the rules put forth in
    [I-D.ietf-netmod-yang-module-versioning] are designed to work well
    with existing versions of YANG and allow for artifact authors to
@@ -295,6 +328,15 @@ Internet-Draft                 YANG Semver                 February 2024
 
    As stated above, the YANG semantic version is expressed as a string
    of the form: 'X.Y.Z_COMPAT'.
+
+
+
+
+
+Clarke, et al.           Expires 23 August 2024                 [Page 6]
+
+Internet-Draft                 YANG Semver                 February 2024
+
 
    *  'X' is the MAJOR version.  Changes in the MAJOR version number
       indicate changes that are non-backwards-compatible to versions
@@ -329,15 +371,6 @@ Internet-Draft                 YANG Semver                 February 2024
       -  If the modifier string is absent, the change represents an
          editorial change.
 
-
-
-
-
-Clarke, et al.           Expires 23 August 2024                 [Page 6]
-
-Internet-Draft                 YANG Semver                 February 2024
-
-
       -  If, however, the modifier string is present, the meaning is
          described below:
 
@@ -353,6 +386,14 @@ Internet-Draft                 YANG Semver                 February 2024
    will also have a modifier.  The modifier can change from
    "_compatible" to "_non_compatible" in a subsequent version, but the
    modifier MUST NOT change from "_non_compatible" to "_compatible" and
+
+
+
+Clarke, et al.           Expires 23 August 2024                 [Page 7]
+
+Internet-Draft                 YANG Semver                 February 2024
+
+
    MUST NOT be removed.  The persistence of the "_non_compatible"
    modifier ensures that comparisons of versions do not give the false
    impression of compatibility between two potentially non-compatible
@@ -374,7 +415,7 @@ Internet-Draft                 YANG Semver                 February 2024
    modifier strings.  E.g., artifact version "1.2.3_non_compatible" MUST
    NOT be defined if artifact version "1.2.3" has already been defined.
 
-3.4.1.  Branching Limitations with YANG Semver
+4.4.1.  Branching Limitations with YANG Semver
 
    YANG artifacts that use the YANG Semver version scheme MUST ensure
    that two artifacts with the same MAJOR version number and no
@@ -382,17 +423,6 @@ Internet-Draft                 YANG Semver                 February 2024
    Therefore, certain branching schemes cannot be used with YANG Semver.
    For example, the following branching approach using the following
    YANG Semver identifiers is not supported:
-
-
-
-
-
-
-
-Clarke, et al.           Expires 23 August 2024                 [Page 7]
-
-Internet-Draft                 YANG Semver                 February 2024
-
 
          3.5.0 -- 3.6.0 (add leaf foo)
            |
@@ -408,7 +438,19 @@ Internet-Draft                 YANG Semver                 February 2024
    branch have different backwards compatible changes is allowed in
    [I-D.ietf-netmod-yang-module-versioning].
 
-3.4.2.  YANG Semver with submodules
+
+
+
+
+
+
+
+Clarke, et al.           Expires 23 August 2024                 [Page 8]
+
+Internet-Draft                 YANG Semver                 February 2024
+
+
+4.4.2.  YANG Semver with submodules
 
    YANG Semver MAY be used to version submodules.  Submodule version are
    separate of any version on the including module, but if a submodule
@@ -416,7 +458,7 @@ Internet-Draft                 YANG Semver                 February 2024
    updated.
 
    The rules for determining the version change of a submodule are the
-   same as those defined in Section 3.3 and Section 3.4 as applied to
+   same as those defined in Section 4.3 and Section 4.4 as applied to
    YANG modules, except they only apply to the part of the module schema
    defined within the submodule's file.
 
@@ -437,20 +479,32 @@ Internet-Draft                 YANG Semver                 February 2024
    submodules belonging to the same module (e.g. groupings and typedefs
    declared in one submodule and used in another).
 
-3.4.3.  Examples for YANG semantic versions
+4.4.3.  Examples for YANG semantic versions
 
    The following diagram and explanation illustrate how YANG semantic
    versions work.
 
+   YANG Semantic versions for an example module:
 
 
 
-Clarke, et al.           Expires 23 August 2024                 [Page 8]
+
+
+
+
+
+
+
+
+
+
+
+
+
+Clarke, et al.           Expires 23 August 2024                 [Page 9]
 
 Internet-Draft                 YANG Semver                 February 2024
 
-
-   YANG Semantic versions for an example module:
 
             0.1.0
               |
@@ -501,7 +555,9 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                 [Page 9]
+
+
+Clarke, et al.           Expires 23 August 2024                [Page 10]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -522,7 +578,7 @@ Internet-Draft                 YANG Semver                 February 2024
       1.2.2_non_compatible - backport "wibble".  This is a BC change but
       "non_compatible" modifier is sticky.  (BC)
 
-3.5.  YANG Semantic Version Update Rules
+4.5.  YANG Semantic Version Update Rules
 
    When a new version of an artifact is produced, then the following
    rules define how the YANG semantic version for the new artifact is
@@ -557,7 +613,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 10]
+Clarke, et al.           Expires 23 August 2024                [Page 11]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -580,11 +636,11 @@ Internet-Draft                 YANG Semver                 February 2024
        not follow the rules above.  Either the MINOR or PATCH version
        numbers may be updated, regardless of whether the changes are
        non-backwards-compatible, backwards-compatible, or editorial.
-       See Section 5 for more details on using this notation during
+       See Section 6 for more details on using this notation during
        module and submodule development.
 
    5.  Additional pre-release rules for modules that have had at least
-       one release are specified in Section 5.
+       one release are specified in Section 6.
 
    Although artifacts SHOULD be updated according to the rules above,
    which specify the recommended (and minimum required) update to the
@@ -613,7 +669,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 11]
+Clarke, et al.           Expires 23 August 2024                [Page 12]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -628,9 +684,9 @@ Internet-Draft                 YANG Semver                 February 2024
    version has been incremented it does not necessarily mean that a
    "rev:non-backwards-compatible" statement would be present.
 
-3.6.  Examples of the YANG Semver Label
+4.6.  Examples of the YANG Semver Label
 
-3.6.1.  Example Module Using YANG Semver
+4.6.1.  Example Module Using YANG Semver
 
    Below is a sample YANG module that uses YANG Semver based on the
    rules defined in this document.
@@ -641,7 +697,7 @@ Internet-Draft                 YANG Semver                 February 2024
        prefix "exvermod";
 
        import ietf-yang-revisions { prefix "rev"; }
-   import ietf-yang-semver { prefix "ys"; }
+       import ietf-yang-semver { prefix "ys"; }
 
        description
          "to be completed";
@@ -669,7 +725,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 12]
+Clarke, et al.           Expires 23 August 2024                [Page 13]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -702,7 +758,7 @@ Internet-Draft                 YANG Semver                 February 2024
        //YANG module definition starts here
      }
 
-3.6.2.  Example of Package Using YANG Semver
+4.6.2.  Example of Package Using YANG Semver
 
    Below is an example YANG package that uses the YANG Semver revision
    label based on the rules defined in this document.  Note: '\' line
@@ -725,7 +781,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 13]
+Clarke, et al.           Expires 23 August 2024                [Page 14]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -753,9 +809,9 @@ Internet-Draft                 YANG Semver                 February 2024
      }
    }
 
-                                  Figure 1
+                                  Figure 2
 
-4.  Import Module by YANG Semantic Version
+5.  Import Module by YANG Semantic Version
 
    [I-D.ietf-netmod-yang-module-versioning] allows for imports to be
    done based on the earliest supported date and later using the
@@ -763,7 +819,7 @@ Internet-Draft                 YANG Semver                 February 2024
    extension for controlling import by YANG semantic version, as well as
    the rules for how imports are resolved.
 
-4.1.  The recommended-min-version Extension
+5.1.  The recommended-min-version Extension
 
    The ietf-yang-semver module defines a "recommended-min-version"
    extension -- a substatement to the "import" statement -- that takes a
@@ -771,7 +827,7 @@ Internet-Draft                 YANG Semver                 February 2024
    version of the associated module being imported SHOULD be greater
    than or equal to the specified value.  The specific conditions for
    determining if a module's version is greater than or equal is defined
-   in Section 4.2 below.  Multiple recommended-min-version statements
+   in Section 5.2 below.  Multiple recommended-min-version statements
    MAY be specified.  If there are multiple recommended-min-version
    statements, they are treated as a logical OR.  Removing recommended-
    min-version statements is considered a backwards compatible change.
@@ -781,7 +837,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 14]
+Clarke, et al.           Expires 23 August 2024                [Page 15]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -790,7 +846,7 @@ Internet-Draft                 YANG Semver                 February 2024
                ys:recommended-min-version 3.0.0;
            }
 
-4.2.  Import by YANG Semantic Version Rules
+5.2.  Import by YANG Semantic Version Rules
 
    A module to be imported is considered viable with recommended-min-
    version if it meets one of the following conditions:
@@ -827,7 +883,7 @@ Internet-Draft                 YANG Semver                 February 2024
    compiler SHOULD emit a warning, and then continue to resolve the
    import based on established [RFC7950] rules.
 
-5.  Guidelines for Using Semver During Module Development
+6.  Guidelines for Using Semver During Module Development
 
    This section and the IETF-specific sub-section below provides YANG
    Semver-specific guidelines to consider when developing new YANG
@@ -837,7 +893,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 15]
+Clarke, et al.           Expires 23 August 2024                [Page 16]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -893,7 +949,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 16]
+Clarke, et al.           Expires 23 August 2024                [Page 17]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -906,7 +962,7 @@ Internet-Draft                 YANG Semver                 February 2024
    version might be 2.0.0-202005-alpha.1 if keeping the same year and
    month notation mentioned above).
 
-5.1.  Pre-release Version Precedence
+6.1.  Pre-release Version Precedence
 
    As a module or submodule is developed, the scope of the work may
    change.  That is, while a released module or submodule with version
@@ -925,7 +981,7 @@ Internet-Draft                 YANG Semver                 February 2024
    appendix in the associated draft to track overall changes to the
    module or submodule.
 
-5.2.  YANG Semver in IETF Modules
+6.2.  YANG Semver in IETF Modules
 
    All published IETF modules and submodules MUST use YANG semantic
    versions in their revisions.
@@ -938,7 +994,7 @@ Internet-Draft                 YANG Semver                 February 2024
    compatible with the current RFC release, the MINOR version number
    MUST be 0.
 
-5.2.1.  Guidelines for IETF Module Development
+6.2.1.  Guidelines for IETF Module Development
 
    All IETF modules and submodules in development MUST use the whole
    document name as a pre-release version identifier, including the
@@ -949,7 +1005,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 17]
+Clarke, et al.           Expires 23 August 2024                [Page 18]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -970,13 +1026,13 @@ Internet-Draft                 YANG Semver                 February 2024
 
    See Appendix A for a detailed example of IETF pre-release versions.
 
-5.2.2.  Guidelines for Published IETF Modules
+6.2.2.  Guidelines for Published IETF Modules
 
    For IETF YANG modules and submodules that have already been
    published, versions MUST be retroactively applied to all existing
    revisions when the next new revision is created, starting at version
    "1.0.0" for the initial published revision, and then incrementing
-   according to the YANG Semver version rules specified in Section 3.5.
+   according to the YANG Semver version rules specified in Section 4.5.
    For example, if a module or submodule started out in the pre-NMDA
    ([RFC8342] ) world, and then had NMDA support added without removing
    any legacy "state" branches -- and you are looking to add additional
@@ -984,7 +1040,7 @@ Internet-Draft                 YANG Semver                 February 2024
    1.2.0 (since 1.0.0 would have been the initial, pre-NMDA release, and
    1.1.0 would have been the NMDA revision).
 
-6.  YANG Module
+7.  YANG Module
 
    This YANG module contains the typedef for the YANG semantic version
    and the identity to signal its use.
@@ -1005,7 +1061,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 18]
+Clarke, et al.           Expires 23 August 2024                [Page 19]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1061,7 +1117,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 19]
+Clarke, et al.           Expires 23 August 2024                [Page 20]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1117,7 +1173,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 20]
+Clarke, et al.           Expires 23 August 2024                [Page 21]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1163,7 +1219,7 @@ Internet-Draft                 YANG Semver                 February 2024
    }
    <CODE ENDS>
 
-7.  Contributors
+8.  Contributors
 
    The following people made substantial contributions to this document:
 
@@ -1173,7 +1229,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 21]
+Clarke, et al.           Expires 23 August 2024                [Page 22]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1185,9 +1241,9 @@ Internet-Draft                 YANG Semver                 February 2024
      jlindbla@cisco.com
 
 
-                                  Figure 2
+                                  Figure 3
 
-8.  Acknowledgments
+9.  Acknowledgments
 
    This document grew out of the YANG module versioning design team that
    started after IETF 101.  The team consists of the following members
@@ -1209,7 +1265,7 @@ Internet-Draft                 YANG Semver                 February 2024
    We would also like to thank Joseph Donahue from the SemVer.org
    project for his input on SemVer use and overall document readability.
 
-9.  Security Considerations
+10.  Security Considerations
 
    The YANG module specified in this document defines a schema for data
    that is designed to be accessed via network management protocols such
@@ -1229,7 +1285,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 22]
+Clarke, et al.           Expires 23 August 2024                [Page 23]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1238,9 +1294,9 @@ Internet-Draft                 YANG Semver                 February 2024
    writeable nodes.  The extensions defined are only used to document
    YANG artifacts.
 
-10.  IANA Considerations
+11.  IANA Considerations
 
-10.1.  YANG Module Registrations
+11.1.  YANG Module Registrations
 
    This document requests IANA to register a URI in the "IETF XML
    Registry" [RFC3688].  Following the format in RFC 3688, the following
@@ -1266,7 +1322,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
       Reference: [RFCXXXX]
 
-10.2.  Guidance for YANG Semver in IANA maintained YANG modules and
+11.2.  Guidance for YANG Semver in IANA maintained YANG modules and
        submodules
 
    Note for IANA (to be removed by the RFC editor): Please check that
@@ -1280,25 +1336,25 @@ Internet-Draft                 YANG Semver                 February 2024
    In addition to following the rules specified in the IANA
    Considerations section of [I-D.ietf-netmod-yang-module-versioning],
    IANA maintained YANG modules and submodules MUST also include a YANG
-   Semver revision label for all new revisions, as defined in Section 3.
+   Semver revision label for all new revisions, as defined in Section 4.
 
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 23]
+Clarke, et al.           Expires 23 August 2024                [Page 24]
 
 Internet-Draft                 YANG Semver                 February 2024
 
 
    The YANG Semver version associated with the new revision MUST follow
-   the rules defined in Section 3.5.
+   the rules defined in Section 4.5.
 
    Note: For IANA maintained YANG modules and submodules that have
    already been published, versions MUST be retroactively applied to all
    existing revisions when the next new revision is created, starting at
    version "1.0.0" for the initial published revision, and then
    incrementing according to the YANG Semver rules specified in
-   Section 3.5.
+   Section 4.5.
 
    Most changes to IANA maintained YANG modules and submodules are
    expected to be backwards-compatible changes and classified as MINOR
@@ -1311,9 +1367,9 @@ Internet-Draft                 YANG Semver                 February 2024
    "_compatible" or "_non_compatible" modifiers to the "Z_COMPAT"
    version element.
 
-11.  References
+12.  References
 
-11.1.  Normative References
+12.1.  Normative References
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
@@ -1341,7 +1397,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 24]
+Clarke, et al.           Expires 23 August 2024                [Page 25]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1358,7 +1414,7 @@ Internet-Draft                 YANG Semver                 February 2024
               <https://datatracker.ietf.org/doc/html/draft-ietf-netmod-
               yang-module-versioning-10>.
 
-11.2.  Informative References
+12.2.  Informative References
 
    [I-D.clacla-netmod-yang-model-update]
               Claise, B., Clarke, J., Lengyel, B., and K. D'Souza, "New
@@ -1397,7 +1453,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 25]
+Clarke, et al.           Expires 23 August 2024                [Page 26]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1453,7 +1509,7 @@ Appendix A.  Example IETF Module Development
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 26]
+Clarke, et al.           Expires 23 August 2024                [Page 27]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1509,7 +1565,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 27]
+Clarke, et al.           Expires 23 August 2024                [Page 28]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1565,4 +1621,4 @@ Authors' Addresses
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 28]
+Clarke, et al.           Expires 23 August 2024                [Page 29]

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -147,7 +147,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
    Example YANG module with branched revision history.
 
-          Module revision date        Version Identifier
+          Module revision date      Example version identifier
             2019-01-01                 <- 1.0.0
                 |
             2019-02-01                 <- 2.0.0
@@ -156,9 +156,9 @@ Internet-Draft                 YANG Semver                 February 2024
                 |        \
                 |       2019-04-01     <- 2.1.0
                 |           |
-                |       2019-05-01     <- 2.2.0
-                |
-            2019-06-01                 <- 3.1.0
+            2019-05-01      |          <- 3.1.0
+                            |
+                        2019-06-01     <- 2.2.0
 
                                   Figure 1
 

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -6,14 +6,14 @@ Network Working Group                                     J. Clarke, Ed.
 Internet-Draft                                            R. Wilton, Ed.
 Updates: 8407 (if approved)                          Cisco Systems, Inc.
 Intended status: Standards Track                               R. Rahman
-Expires: 26 July 2024                                          Graphiant
+Expires: 16 August 2024                                        Graphiant
                                                               B. Lengyel
                                                                 Ericsson
                                                                J. Sterne
                                                                    Nokia
                                                                B. Claise
                                                                   Huawei
-                                                         23 January 2024
+                                                        13 February 2024
 
 
                         YANG Semantic Versioning
@@ -42,7 +42,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 26 July 2024.
+   This Internet-Draft will expire on 16 August 2024.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Clarke, et al.            Expires 26 July 2024                  [Page 1]
+Clarke, et al.           Expires 16 August 2024                 [Page 1]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Clarke, et al.            Expires 26 July 2024                  [Page 2]
+Clarke, et al.           Expires 16 August 2024                 [Page 2]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
 1.  Introduction
@@ -165,9 +165,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                  [Page 3]
+Clarke, et al.           Expires 16 August 2024                 [Page 3]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
 3.  YANG Semantic Versioning
@@ -221,9 +221,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                  [Page 4]
+Clarke, et al.           Expires 16 August 2024                 [Page 4]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
    character.  Build metadata MAY be appended after a trailing '+'
@@ -277,9 +277,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                  [Page 5]
+Clarke, et al.           Expires 16 August 2024                 [Page 5]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
    Because the rules put forth in
@@ -333,9 +333,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                  [Page 6]
+Clarke, et al.           Expires 16 August 2024                 [Page 6]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
       -  If, however, the modifier string is present, the meaning is
@@ -389,9 +389,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                  [Page 7]
+Clarke, et al.           Expires 16 August 2024                 [Page 7]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
          3.5.0 -- 3.6.0 (add leaf foo)
@@ -445,9 +445,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                  [Page 8]
+Clarke, et al.           Expires 16 August 2024                 [Page 8]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
    YANG Semantic versions for an example module:
@@ -501,9 +501,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                  [Page 9]
+Clarke, et al.           Expires 16 August 2024                 [Page 9]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
       1.3.1_non_compatible - backport NBC fix, rename "baz" to "bar"
@@ -557,9 +557,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                 [Page 10]
+Clarke, et al.           Expires 16 August 2024                [Page 10]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
    3.  If an artifact is being updated in an editorial way, then the
@@ -613,9 +613,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                 [Page 11]
+Clarke, et al.           Expires 16 August 2024                [Page 11]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
    [I-D.ietf-netmod-yang-module-versioning] defines the "rev:non-
@@ -632,8 +632,8 @@ Internet-Draft                 YANG Semver                  January 2024
 
 3.6.1.  Example Module Using YANG Semver
 
-   Below is a sample YANG module that uses the YANG Semver revision-
-   label based on the rules defined in this document.
+   Below is a sample YANG module that uses YANG Semver based on the
+   rules defined in this document.
 
      module example-versioned-module {
        yang-version 1.1;
@@ -669,9 +669,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                 [Page 12]
+Clarke, et al.           Expires 16 August 2024                [Page 12]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
        revision 2017-02-07 {
@@ -725,9 +725,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                 [Page 13]
+Clarke, et al.           Expires 16 August 2024                [Page 13]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
    {
@@ -781,9 +781,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                 [Page 14]
+Clarke, et al.           Expires 16 August 2024                [Page 14]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
            import example-module {
@@ -837,9 +837,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                 [Page 15]
+Clarke, et al.           Expires 16 August 2024                [Page 15]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
    Development of a brand new YANG module or submodule outside of the
@@ -893,9 +893,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                 [Page 16]
+Clarke, et al.           Expires 16 August 2024                [Page 16]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
    both versions (e.g., 2.0.0-alpha.3 becomes 1.1.0-alpha.4).  However,
@@ -949,9 +949,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                 [Page 17]
+Clarke, et al.           Expires 16 August 2024                [Page 17]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
    followed by the document's revision (e.g., 2.0.0-draft-user-netmod-
@@ -1005,9 +1005,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                 [Page 18]
+Clarke, et al.           Expires 16 August 2024                [Page 18]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
                   <mailto:jclarke@cisco.com>
@@ -1048,7 +1048,7 @@ Internet-Draft                 YANG Semver                  January 2024
      // and remove this note.
      // RFC Ed.: replace XXXX with actual RFC number and remove this
      // note.
-     // RFC Ed. update the rev:revision-label to "1.0.0".
+     // RFC Ed. update the ysver:version to "1.0.0".
 
      revision 2024-01-22 {
        ysver:version "1.0.0-draft-ietf-netmod-yang-semver-13";
@@ -1061,9 +1061,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                 [Page 19]
+Clarke, et al.           Expires 16 August 2024                [Page 19]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
      /*
@@ -1117,9 +1117,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                 [Page 20]
+Clarke, et al.           Expires 16 August 2024                [Page 20]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
           satisfies at least one of the 'recommended-min-version'
@@ -1173,9 +1173,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                 [Page 21]
+Clarke, et al.           Expires 16 August 2024                [Page 21]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
      Bo Wu
@@ -1229,9 +1229,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                 [Page 22]
+Clarke, et al.           Expires 16 August 2024                [Page 22]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
    That said, the YANG module in this document does not define any
@@ -1285,9 +1285,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                 [Page 23]
+Clarke, et al.           Expires 16 August 2024                [Page 23]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
    The YANG Semver version associated with the new revision MUST follow
@@ -1341,9 +1341,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                 [Page 24]
+Clarke, et al.           Expires 16 August 2024                [Page 24]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
    [RFC7950]  Bjorklund, M., Ed., "The YANG 1.1 Data Modeling Language",
@@ -1397,9 +1397,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                 [Page 25]
+Clarke, et al.           Expires 16 August 2024                [Page 25]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
    [RFC8040]  Bierman, A., Bjorklund, M., and K. Watsen, "RESTCONF
@@ -1444,7 +1444,7 @@ Appendix A.  Example IETF Module Development
    group in the IETF.  Initially, this module is being developed in an
    individual internet draft, draft-jdoe-netmod-example-module.  The
    following represents the initial version tree (i.e., value of
-   revision-label) of the module as it's being initially developed.
+   ysver:version) of the module as it's being initially developed.
 
    Version lineage for initial module development:
 
@@ -1453,9 +1453,9 @@ Appendix A.  Example IETF Module Development
 
 
 
-Clarke, et al.            Expires 26 July 2024                 [Page 26]
+Clarke, et al.           Expires 16 August 2024                [Page 26]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
          0.0.1-draft-jdoe-netmod-example-module-00
@@ -1509,9 +1509,9 @@ Internet-Draft                 YANG Semver                  January 2024
 
 
 
-Clarke, et al.            Expires 26 July 2024                 [Page 27]
+Clarke, et al.           Expires 16 August 2024                [Page 27]
 
-Internet-Draft                 YANG Semver                  January 2024
+Internet-Draft                 YANG Semver                 February 2024
 
 
          1.1.0-draft-ietf-netmod-exmod-changes-00
@@ -1565,4 +1565,4 @@ Authors' Addresses
 
 
 
-Clarke, et al.            Expires 26 July 2024                 [Page 28]
+Clarke, et al.           Expires 16 August 2024                [Page 28]

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -6,14 +6,14 @@ Network Working Group                                     J. Clarke, Ed.
 Internet-Draft                                            R. Wilton, Ed.
 Updates: 8407 (if approved)                          Cisco Systems, Inc.
 Intended status: Standards Track                               R. Rahman
-Expires: 24 August 2024                                          Equinix
+Expires: 25 August 2024                                          Equinix
                                                               B. Lengyel
                                                                 Ericsson
                                                                J. Sterne
                                                                    Nokia
                                                                B. Claise
                                                                   Huawei
-                                                        21 February 2024
+                                                        22 February 2024
 
 
                         YANG Semantic Versioning
@@ -42,7 +42,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 24 August 2024.
+   This Internet-Draft will expire on 25 August 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Clarke, et al.           Expires 24 August 2024                 [Page 1]
+Clarke, et al.           Expires 25 August 2024                 [Page 1]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Clarke, et al.           Expires 24 August 2024                 [Page 2]
+Clarke, et al.           Expires 25 August 2024                 [Page 2]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -128,7 +128,7 @@ Internet-Draft                 YANG Semver                 February 2024
    (i.e., YANG modules, YANG submodules, and YANG packages
    [I-D.ietf-netmod-yang-packages] ) with a version identifier that
    adheres to extended semantic versioning rules [SemVer].  The goal
-   being to add a human readable revision label that provides
+   being to add a human readable version identifier that provides
    compatibility information for the YANG artifact without needing to
    compare or parse its body.  The version identifier and rules defined
    herein represent the RECOMMENDED approach to apply versioning to IETF
@@ -165,7 +165,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                 [Page 3]
+Clarke, et al.           Expires 25 August 2024                 [Page 3]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -221,7 +221,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                 [Page 4]
+Clarke, et al.           Expires 25 August 2024                 [Page 4]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -277,7 +277,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                 [Page 5]
+Clarke, et al.           Expires 25 August 2024                 [Page 5]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -333,7 +333,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                 [Page 6]
+Clarke, et al.           Expires 25 August 2024                 [Page 6]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -381,7 +381,7 @@ Internet-Draft                 YANG Semver                 February 2024
          compatible change
 
    The '_COMPAT' modifier string is "sticky".  Once a revision of a
-   module has a modifier in the revision label, then all subsequent
+   module has a modifier in the version identifier, then all subsequent
    modules in that branch (i.e., those with the same X.Y version digits)
    will also have a modifier.  The modifier can change from
    "_compatible" to "_non_compatible" in a subsequent version, but the
@@ -389,7 +389,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                 [Page 7]
+Clarke, et al.           Expires 25 August 2024                 [Page 7]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -445,7 +445,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                 [Page 8]
+Clarke, et al.           Expires 25 August 2024                 [Page 8]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -501,7 +501,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                 [Page 9]
+Clarke, et al.           Expires 25 August 2024                 [Page 9]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -557,7 +557,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                [Page 10]
+Clarke, et al.           Expires 25 August 2024                [Page 10]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -613,7 +613,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                [Page 11]
+Clarke, et al.           Expires 25 August 2024                [Page 11]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -669,7 +669,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                [Page 12]
+Clarke, et al.           Expires 25 August 2024                [Page 12]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -725,7 +725,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                [Page 13]
+Clarke, et al.           Expires 25 August 2024                [Page 13]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -760,9 +760,9 @@ Internet-Draft                 YANG Semver                 February 2024
 
 4.6.2.  Example of Package Using YANG Semver
 
-   Below is an example YANG package that uses the YANG Semver revision
-   label based on the rules defined in this document.  Note: '\' line
-   wrapping per [RFC8792].
+   Below is an example YANG package that uses the YANG Semver version
+   identifier based on the rules defined in this document.  Note: '\'
+   line wrapping per [RFC8792].
 
 
 
@@ -781,7 +781,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                [Page 14]
+Clarke, et al.           Expires 25 August 2024                [Page 14]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -837,7 +837,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                [Page 15]
+Clarke, et al.           Expires 25 August 2024                [Page 15]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -893,7 +893,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                [Page 16]
+Clarke, et al.           Expires 25 August 2024                [Page 16]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -949,7 +949,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                [Page 17]
+Clarke, et al.           Expires 25 August 2024                [Page 17]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1005,7 +1005,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                [Page 18]
+Clarke, et al.           Expires 25 August 2024                [Page 18]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1061,7 +1061,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                [Page 19]
+Clarke, et al.           Expires 25 August 2024                [Page 19]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1117,7 +1117,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                [Page 20]
+Clarke, et al.           Expires 25 August 2024                [Page 20]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1133,11 +1133,11 @@ Internet-Draft                 YANG Semver                 February 2024
           identifier associated with a module or submodule
           revision.
 
-          The format of the revision label argument MUST conform to the
-          'version' typedef defined in this module.
+          The format of the version extension argument MUST conform
+          to the 'version' typedef defined in this module.
 
           The statement MUST only be a substatement of the revision
-          statement.  Zero or one revision label statements per parent
+          statement.  Zero or one version statements per parent
           statement are allowed.  No substatements for this extension
           have been standardized.
 
@@ -1173,7 +1173,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                [Page 21]
+Clarke, et al.           Expires 25 August 2024                [Page 21]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1211,7 +1211,7 @@ Internet-Draft                 YANG Semver                 February 2024
        }
        description
          "Represents a YANG semantic version.  The rules governing the
-          use of this revision label scheme are defined in the
+          use of this version identifier are defined in the
           reference for this typedef.";
        reference
          "RFC XXXX: YANG Semantic Versioning.";
@@ -1229,7 +1229,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                [Page 22]
+Clarke, et al.           Expires 25 August 2024                [Page 22]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1285,7 +1285,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                [Page 23]
+Clarke, et al.           Expires 25 August 2024                [Page 23]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1336,12 +1336,12 @@ Internet-Draft                 YANG Semver                 February 2024
    In addition to following the rules specified in the IANA
    Considerations section of [I-D.ietf-netmod-yang-module-versioning],
    IANA maintained YANG modules and submodules MUST also include a YANG
-   Semver revision label for all new revisions, as defined in Section 4.
+   Semver version identifier for all new revisions, as defined in
+   Section 4.
 
 
 
-
-Clarke, et al.           Expires 24 August 2024                [Page 24]
+Clarke, et al.           Expires 25 August 2024                [Page 24]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1397,7 +1397,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                [Page 25]
+Clarke, et al.           Expires 25 August 2024                [Page 25]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1453,7 +1453,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                [Page 26]
+Clarke, et al.           Expires 25 August 2024                [Page 26]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1509,7 +1509,7 @@ Appendix A.  Example IETF Module Development
 
 
 
-Clarke, et al.           Expires 24 August 2024                [Page 27]
+Clarke, et al.           Expires 25 August 2024                [Page 27]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1565,7 +1565,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 24 August 2024                [Page 28]
+Clarke, et al.           Expires 25 August 2024                [Page 28]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1621,4 +1621,4 @@ Authors' Addresses
 
 
 
-Clarke, et al.           Expires 24 August 2024                [Page 29]
+Clarke, et al.           Expires 25 August 2024                [Page 29]

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -6,18 +6,18 @@ Network Working Group                                     J. Clarke, Ed.
 Internet-Draft                                            R. Wilton, Ed.
 Updates: 8407, 8525, 7950 (if approved)              Cisco Systems, Inc.
 Intended status: Standards Track                               R. Rahman
-Expires: 3 September 2024                                        Equinix
+Expires: 5 September 2024                                        Equinix
                                                               B. Lengyel
                                                                 Ericsson
                                                                J. Sterne
                                                                    Nokia
                                                                B. Claise
                                                                   Huawei
-                                                            2 March 2024
+                                                            4 March 2024
 
 
                         YANG Semantic Versioning
-                    draft-ietf-netmod-yang-semver-13
+                    draft-ietf-netmod-yang-semver-14
 
 Abstract
 
@@ -43,7 +43,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 3 September 2024.
+   This Internet-Draft will expire on 5 September 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Clarke, et al.          Expires 3 September 2024                [Page 1]
+Clarke, et al.          Expires 5 September 2024                [Page 1]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Clarke, et al.          Expires 3 September 2024                [Page 2]
+Clarke, et al.          Expires 5 September 2024                [Page 2]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -165,7 +165,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024                [Page 3]
+Clarke, et al.          Expires 5 September 2024                [Page 3]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -221,7 +221,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024                [Page 4]
+Clarke, et al.          Expires 5 September 2024                [Page 4]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -277,7 +277,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024                [Page 5]
+Clarke, et al.          Expires 5 September 2024                [Page 5]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -333,7 +333,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024                [Page 6]
+Clarke, et al.          Expires 5 September 2024                [Page 6]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -389,7 +389,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024                [Page 7]
+Clarke, et al.          Expires 5 September 2024                [Page 7]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -445,7 +445,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024                [Page 8]
+Clarke, et al.          Expires 5 September 2024                [Page 8]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -501,7 +501,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024                [Page 9]
+Clarke, et al.          Expires 5 September 2024                [Page 9]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -557,7 +557,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 10]
+Clarke, et al.          Expires 5 September 2024               [Page 10]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -613,7 +613,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 11]
+Clarke, et al.          Expires 5 September 2024               [Page 11]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -669,7 +669,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 12]
+Clarke, et al.          Expires 5 September 2024               [Page 12]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -725,7 +725,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 13]
+Clarke, et al.          Expires 5 September 2024               [Page 13]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -781,7 +781,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 14]
+Clarke, et al.          Expires 5 September 2024               [Page 14]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -837,7 +837,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 15]
+Clarke, et al.          Expires 5 September 2024               [Page 15]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -893,7 +893,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 16]
+Clarke, et al.          Expires 5 September 2024               [Page 16]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -949,7 +949,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 17]
+Clarke, et al.          Expires 5 September 2024               [Page 17]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1005,7 +1005,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 18]
+Clarke, et al.          Expires 5 September 2024               [Page 18]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1061,7 +1061,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 19]
+Clarke, et al.          Expires 5 September 2024               [Page 19]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1117,7 +1117,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 20]
+Clarke, et al.          Expires 5 September 2024               [Page 20]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1173,7 +1173,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 21]
+Clarke, et al.          Expires 5 September 2024               [Page 21]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1229,7 +1229,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 22]
+Clarke, et al.          Expires 5 September 2024               [Page 22]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1285,7 +1285,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 23]
+Clarke, et al.          Expires 5 September 2024               [Page 23]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1341,7 +1341,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 24]
+Clarke, et al.          Expires 5 September 2024               [Page 24]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1397,7 +1397,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 25]
+Clarke, et al.          Expires 5 September 2024               [Page 25]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1453,7 +1453,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 26]
+Clarke, et al.          Expires 5 September 2024               [Page 26]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1509,7 +1509,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 27]
+Clarke, et al.          Expires 5 September 2024               [Page 27]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1565,7 +1565,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 28]
+Clarke, et al.          Expires 5 September 2024               [Page 28]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1621,7 +1621,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 29]
+Clarke, et al.          Expires 5 September 2024               [Page 29]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1677,7 +1677,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 30]
+Clarke, et al.          Expires 5 September 2024               [Page 30]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1733,7 +1733,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 31]
+Clarke, et al.          Expires 5 September 2024               [Page 31]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1789,7 +1789,7 @@ Appendix A.  Example IETF Module Development
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 32]
+Clarke, et al.          Expires 5 September 2024               [Page 32]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1845,7 +1845,7 @@ Authors' Addresses
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 33]
+Clarke, et al.          Expires 5 September 2024               [Page 33]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1901,4 +1901,4 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 3 September 2024               [Page 34]
+Clarke, et al.          Expires 5 September 2024               [Page 34]

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -17,7 +17,7 @@ Expires: 13 September 2024                                       Equinix
 
 
                         YANG Semantic Versioning
-                    draft-ietf-netmod-yang-semver-14
+                    draft-ietf-netmod-yang-semver-15
 
 Abstract
 

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -6,14 +6,14 @@ Network Working Group                                     J. Clarke, Ed.
 Internet-Draft                                            R. Wilton, Ed.
 Updates: 8407, 8525, 7950 (if approved)              Cisco Systems, Inc.
 Intended status: Standards Track                               R. Rahman
-Expires: 5 September 2024                                        Equinix
+Expires: 13 September 2024                                       Equinix
                                                               B. Lengyel
                                                                 Ericsson
                                                                J. Sterne
                                                                    Nokia
                                                                B. Claise
                                                                   Huawei
-                                                            4 March 2024
+                                                           12 March 2024
 
 
                         YANG Semantic Versioning
@@ -43,7 +43,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 5 September 2024.
+   This Internet-Draft will expire on 13 September 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Clarke, et al.          Expires 5 September 2024                [Page 1]
+Clarke, et al.          Expires 13 September 2024               [Page 1]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -88,19 +88,19 @@ Table of Contents
    5.  Import Module by YANG Semantic Version  . . . . . . . . . . .  15
      5.1.  The recommended-min-version Extension . . . . . . . . . .  15
      5.2.  Import by YANG Semantic Version Rules . . . . . . . . . .  16
-   6.  Guidelines for Using Semver During Module Development . . . .  16
+   6.  Guidelines for Using Semver During Module Development . . . .  17
      6.1.  Pre-release Version Precedence  . . . . . . . . . . . . .  18
      6.2.  YANG Semver in IETF Modules . . . . . . . . . . . . . . .  18
-       6.2.1.  Guidelines for IETF Module Development  . . . . . . .  18
+       6.2.1.  Guidelines for IETF Module Development  . . . . . . .  19
        6.2.2.  Guidelines for Published IETF Modules . . . . . . . .  19
    7.  Updates to ietf-yang-library  . . . . . . . . . . . . . . . .  19
-     7.1.  YANG library versioning augmentations . . . . . . . . . .  19
+     7.1.  YANG library versioning augmentations . . . . . . . . . .  20
        7.1.1.  Advertising version . . . . . . . . . . . . . . . . .  20
    8.  YANG Modules  . . . . . . . . . . . . . . . . . . . . . . . .  20
    9.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  26
    10. Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  27
    11. Security Considerations . . . . . . . . . . . . . . . . . . .  27
-   12. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  27
+   12. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  28
      12.1.  YANG Module Registrations  . . . . . . . . . . . . . . .  28
      12.2.  Guidance for YANG Semver in IANA maintained YANG modules
             and submodules . . . . . . . . . . . . . . . . . . . . .  29
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Clarke, et al.          Expires 5 September 2024                [Page 2]
+Clarke, et al.          Expires 13 September 2024               [Page 2]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -165,7 +165,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 5 September 2024                [Page 3]
+Clarke, et al.          Expires 13 September 2024               [Page 3]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -221,7 +221,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 5 September 2024                [Page 4]
+Clarke, et al.          Expires 13 September 2024               [Page 4]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -277,7 +277,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 5 September 2024                [Page 5]
+Clarke, et al.          Expires 13 September 2024               [Page 5]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -333,7 +333,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 5 September 2024                [Page 6]
+Clarke, et al.          Expires 13 September 2024               [Page 6]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -389,7 +389,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 5 September 2024                [Page 7]
+Clarke, et al.          Expires 13 September 2024               [Page 7]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -445,7 +445,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 5 September 2024                [Page 8]
+Clarke, et al.          Expires 13 September 2024               [Page 8]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -501,7 +501,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 5 September 2024                [Page 9]
+Clarke, et al.          Expires 13 September 2024               [Page 9]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -557,7 +557,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 5 September 2024               [Page 10]
+Clarke, et al.          Expires 13 September 2024              [Page 10]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -613,7 +613,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 5 September 2024               [Page 11]
+Clarke, et al.          Expires 13 September 2024              [Page 11]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -669,7 +669,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 5 September 2024               [Page 12]
+Clarke, et al.          Expires 13 September 2024              [Page 12]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -725,7 +725,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 5 September 2024               [Page 13]
+Clarke, et al.          Expires 13 September 2024              [Page 13]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -781,7 +781,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 5 September 2024               [Page 14]
+Clarke, et al.          Expires 13 September 2024              [Page 14]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -837,7 +837,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 5 September 2024               [Page 15]
+Clarke, et al.          Expires 13 September 2024              [Page 15]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -851,31 +851,37 @@ Internet-Draft                 YANG Semver                    March 2024
    A module to be imported is considered viable with recommended-min-
    version if it meets one of the following conditions:
 
-   1.  Has the same MAJOR and MINOR version numbers and same or greater
-       PATCH number.
+   1.  Has the exact MAJOR, MINOR, PATCH and "_compatible" and
+       "_non_compatible" modifiers as in the recommend-min-version
+       value.
 
-   2.  Has the same MAJOR version number and greater MINOR number.  In
-       this case the PATCH number is ignored.
+   2.  Has the same MAJOR and MINOR version numbers a greater PATCH
+       number.  In this case, "_compatible" and "_non_compatible
+       modifiers" are ignored.
 
-   3.  Has a greater MAJOR version number.  In this case MINOR and PATCH
-       numbers are ignored.
+   3.  Has the same MAJOR version number and greater MINOR number.  In
+       this case the PATCH number and the "_compatible" and
+       "_non_compatible" modifiers are ignored.
 
-   In all cases, the "_compatible" and "_non_compatible" version
-   modifiers are ignored.
+   4.  Has a greater MAJOR version number.  In this case MINOR and PATCH
+       numbers and "_compatible" and "_non_compatible" modifiers are
+       ignored.
 
    If the recommended-min-version is specified as 3.1.0, the following
    examples would be viable:
 
-      3.1.1 (by condition 1 above)
+      3.1.0 (by condition 1 above)
 
-      3.2.0 (by condition 2 above)
+      3.1.1 (by condition 2 above)
 
-      4.1.2 (by condition 3 above)
+      3.2.0 (by condition 3 above)
 
-      3.1.1_compatible (by condition 1 above, noting that modifiers are
+      4.1.2 (by condition 4 above)
+
+      3.1.1_compatible (by condition 2 above, noting that modifiers are
       ignored)
 
-      3.1.2_non_compatible (by condition 1 above, noting that modifiers
+      3.1.2_non_compatible (by condition 2 above, noting that modifiers
       are ignored)
 
    If an import by recommended-min-version cannot locate a module with a
@@ -883,20 +889,20 @@ Internet-Draft                 YANG Semver                    March 2024
    compiler SHOULD emit a warning, and then continue to resolve the
    import based on established [RFC7950] rules.
 
+
+
+
+
+Clarke, et al.          Expires 13 September 2024              [Page 16]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
 6.  Guidelines for Using Semver During Module Development
 
    This section and the IETF-specific sub-section below provides YANG
    Semver-specific guidelines to consider when developing new YANG
    modules.  As such this section updates [RFC8407].
-
-
-
-
-
-Clarke, et al.          Expires 5 September 2024               [Page 16]
-
-Internet-Draft                 YANG Semver                    March 2024
-
 
    Development of a brand new YANG module or submodule outside of the
    IETF that uses the YANG Semver versioning scheme SHOULD begin with a
@@ -940,20 +946,20 @@ Internet-Draft                 YANG Semver                    March 2024
    by a vendor or consumed by an end user).  Therefore, it may be
    prudent to include the year or year and month development began
    (e.g., 2.0.0-201907-alpha.1).  As a module or submodule undergoes
+
+
+
+Clarke, et al.          Expires 13 September 2024              [Page 17]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
    development, it is possible that the original intent changes.  For
    example, a 1.0.0 version of a module or submodule that was destined
    to become 2.0.0 after a development cycle may have had a scope change
    such that the final version has no non-backwards-compatible changes
    and becomes 1.1.0 instead.  This change is acceptable to make during
    the development phase so long as pre-release notation is present in
-
-
-
-Clarke, et al.          Expires 5 September 2024               [Page 17]
-
-Internet-Draft                 YANG Semver                    March 2024
-
-
    both versions (e.g., 2.0.0-alpha.3 becomes 1.1.0-alpha.4).  However,
    on the next development cycle (after 1.1.0 is released), if again the
    new target release is 2.0.0, new pre-release components must be used
@@ -994,6 +1000,16 @@ Internet-Draft                 YANG Semver                    March 2024
    compatible with the current RFC release, the MINOR version number
    MUST be 0.
 
+
+
+
+
+
+Clarke, et al.          Expires 13 September 2024              [Page 18]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
 6.2.1.  Guidelines for IETF Module Development
 
    All IETF modules and submodules in development MUST use the whole
@@ -1002,14 +1018,6 @@ Internet-Draft                 YANG Semver                    March 2024
    which is currently released at version 1.0.0 is being revised to
    include non-backwards-compatible changes in draft-user-netmod-foo,
    its development versions MUST include 2.0.0-draft-user-netmod-foo
-
-
-
-Clarke, et al.          Expires 5 September 2024               [Page 18]
-
-Internet-Draft                 YANG Semver                    March 2024
-
-
    followed by the document's revision (e.g., 2.0.0-draft-user-netmod-
    foo-02).  This will ensure each pre-release version is unique across
    the lifecycle of the module or submodule.  Even when using the 0
@@ -1047,24 +1055,22 @@ Internet-Draft                 YANG Semver                    March 2024
    defines the YANG module, ietf-yang-library-semver, that augments YANG
    library [RFC8525] with a version leaf for modules and submodules.
 
+
+
+
+
+
+
+Clarke, et al.          Expires 13 September 2024              [Page 19]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
 7.1.  YANG library versioning augmentations
 
 
    The "ietf-yang-library-semver" YANG module has the following
    structure (using the notation defined in [RFC8340]):
-
-
-
-
-
-
-
-
-
-Clarke, et al.          Expires 5 September 2024               [Page 19]
-
-Internet-Draft                 YANG Semver                    March 2024
-
 
    module: ietf-yang-library-semver
 
@@ -1108,20 +1114,20 @@ Internet-Draft                 YANG Semver                    March 2024
 
         Author:   Joe Clarke
                   <mailto:jclarke@cisco.com>
+
+
+
+Clarke, et al.          Expires 13 September 2024              [Page 20]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
         Author:   Robert Wilton
                   <mailto:rwilton@cisco.com>
         Author:   Reshad Rahman
                   <mailto:reshad@yahoo.com>
         Author:   Balazs Lengyel
                   <mailto:balazs.lengyel@ericsson.com>
-
-
-
-Clarke, et al.          Expires 5 September 2024               [Page 20]
-
-Internet-Draft                 YANG Semver                    March 2024
-
-
         Author:   Jason Sterne
                   <mailto:jason.sterne@nokia.com>
         Author:   Benoit Claise
@@ -1164,20 +1170,20 @@ Internet-Draft                 YANG Semver                    March 2024
      }
 
      /*
+
+
+
+Clarke, et al.          Expires 13 September 2024              [Page 21]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
       * Extensions
       */
 
      extension version {
        argument yang-semantic-version;
        description
-
-
-
-Clarke, et al.          Expires 5 September 2024               [Page 21]
-
-Internet-Draft                 YANG Semver                    March 2024
-
-
          "The version extension can be used to provide an additional
           identifier associated with a module or submodule
           revision.
@@ -1220,19 +1226,20 @@ Internet-Draft                 YANG Semver                    March 2024
 
           If specified multiple times, then any module revision that
           satisfies at least one of the 'recommended-min-version'
+
+
+
+Clarke, et al.          Expires 13 September 2024              [Page 22]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
           statements is an acceptable recommended version for
           import.
 
           A particular version of an imported module adheres to an
           import's 'recommended-min-version' extension statement if one
           of the following conditions are met:
-
-
-
-Clarke, et al.          Expires 5 September 2024               [Page 22]
-
-Internet-Draft                 YANG Semver                    March 2024
-
 
           * Has the same MAJOR and MINOR version numbers and same or
             greater PATCH number.
@@ -1276,20 +1283,19 @@ Internet-Draft                 YANG Semver                    March 2024
        "urn:ietf:params:xml:ns:yang:ietf-yang-library-semver";
      prefix yl-semver;
 
+
+
+Clarke, et al.          Expires 13 September 2024              [Page 23]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
      import ietf-yang-semver {
        prefix ys;
        reference
          "XXXX: YANG Semantic Versioning";
      }
      import ietf-yang-library {
-
-
-
-Clarke, et al.          Expires 5 September 2024               [Page 23]
-
-Internet-Draft                 YANG Semver                    March 2024
-
-
        prefix yanglib;
        reference
          "RFC 8525: YANG Library";
@@ -1332,19 +1338,19 @@ Internet-Draft                 YANG Semver                    March 2024
         This version of this YANG module is part of RFC XXXX; see
         the RFC itself for full legal notices.
 
+
+
+
+Clarke, et al.          Expires 13 September 2024              [Page 24]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
         The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
         NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
         'MAY', and 'OPTIONAL' in this document are to be interpreted as
         described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
         they appear in all capitals, as shown here.";
-
-
-
-
-Clarke, et al.          Expires 5 September 2024               [Page 24]
-
-Internet-Draft                 YANG Semver                    March 2024
-
 
      // RFC Ed.: update the date below with the date of RFC publication
      // and remove this note.
@@ -1388,20 +1394,20 @@ Internet-Draft                 YANG Semver                    March 2024
          description
            "The version associated with this submodule revision.
             The value MUST match the version value in the
+
+
+
+Clarke, et al.          Expires 13 September 2024              [Page 25]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
             specific revision of the submodule included by the module
             loaded in this module-set.";
          reference
            "XXXX: YANG Semantic Versioning;
             Section 7.1.1, Advertising version";
        }
-
-
-
-Clarke, et al.          Expires 5 September 2024               [Page 25]
-
-Internet-Draft                 YANG Semver                    March 2024
-
-
      }
 
      augment "/yanglib:yang-library/yanglib:module-set/"
@@ -1444,18 +1450,19 @@ Internet-Draft                 YANG Semver                    March 2024
 
    The following people made substantial contributions to this document:
 
+
+
+
+Clarke, et al.          Expires 13 September 2024              [Page 26]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
      Bo Wu
      lana.wubo@huawei.com
 
      Jan Lindblad
      jlindbla@cisco.com
-
-
-
-
-Clarke, et al.          Expires 5 September 2024               [Page 26]
-
-Internet-Draft                 YANG Semver                    March 2024
 
 
                                   Figure 4
@@ -1497,22 +1504,21 @@ Internet-Draft                 YANG Semver                    March 2024
    preconfigured subset of all available NETCONF or RESTCONF protocol
    operations and content.
 
+
+
+
+
+
+Clarke, et al.          Expires 13 September 2024              [Page 27]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
    That said, the YANG module in this document does not define any
    writeable nodes.  The extensions defined are only used to document
    YANG artifacts.
 
 12.  IANA Considerations
-
-
-
-
-
-
-
-Clarke, et al.          Expires 5 September 2024               [Page 27]
-
-Internet-Draft                 YANG Semver                    March 2024
-
 
 12.1.  YANG Module Registrations
 
@@ -1559,13 +1565,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-
-
-
-
-
-
-Clarke, et al.          Expires 5 September 2024               [Page 28]
+Clarke, et al.          Expires 13 September 2024              [Page 28]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1621,7 +1621,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 5 September 2024               [Page 29]
+Clarke, et al.          Expires 13 September 2024              [Page 29]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1677,7 +1677,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 5 September 2024               [Page 30]
+Clarke, et al.          Expires 13 September 2024              [Page 30]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1733,7 +1733,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 5 September 2024               [Page 31]
+Clarke, et al.          Expires 13 September 2024              [Page 31]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1789,7 +1789,7 @@ Appendix A.  Example IETF Module Development
 
 
 
-Clarke, et al.          Expires 5 September 2024               [Page 32]
+Clarke, et al.          Expires 13 September 2024              [Page 32]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1845,7 +1845,7 @@ Authors' Addresses
 
 
 
-Clarke, et al.          Expires 5 September 2024               [Page 33]
+Clarke, et al.          Expires 13 September 2024              [Page 33]
 
 Internet-Draft                 YANG Semver                    March 2024
 
@@ -1901,4 +1901,4 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 5 September 2024               [Page 34]
+Clarke, et al.          Expires 13 September 2024              [Page 34]

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -272,7 +272,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
    Every YANG module and submodule versioned using the YANG semantic
    versioning scheme specifies the module's or submodule's semantic
-   version as the argument to the 'ysver:version' statement.
+   version as the argument to the 'ys:version' statement.
 
 
 
@@ -641,30 +641,30 @@ Internet-Draft                 YANG Semver                 February 2024
        prefix "exvermod";
 
        import ietf-yang-revisions { prefix "rev"; }
-       import ietf-yang-semver { prefix "ysver"; }
+   import ietf-yang-semver { prefix "ys"; }
 
        description
          "to be completed";
 
        revision 2017-08-30 {
          description "Backport 'wibble' leaf";
-         ysver:version 1.2.2_non_compatible;
+         ys:version 1.2.2_non_compatible;
        }
 
        revision 2017-07-30 {
          description "Rename 'baz' to 'bar'";
-         ysver:version 1.2.1_non_compatible;
+         ys:version 1.2.1_non_compatible;
          rev:non-backwards-compatible;
        }
 
        revision 2017-04-20 {
          description "Add new functionality, leaf 'baz'";
-         ysver:version 1.2.0;
+         ys:version 1.2.0;
        }
 
        revision 2017-04-03 {
          description "Add new functionality, leaf 'foo'";
-         ysver:version 1.1.0;
+         ys:version 1.1.0;
        }
 
 
@@ -676,7 +676,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
        revision 2017-02-07 {
          description "First release version.";
-         ysver:version 1.0.0;
+         ys:version 1.0.0;
        }
 
        // Note: YANG Semver rules do not apply to 0.X.Y labels.
@@ -688,7 +688,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
        // revision 2017-01-30 {
        //   description "NBC changes to initial revision";
-       //   ysver:version 0.2.0;
+       //   ys:version 0.2.0;
        //   rev:non-backwards-compatible; // optional
        //                         // (theoretically no
        //                         // 'previous released version')
@@ -696,7 +696,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
        // revision 2017-01-26 {
        //   description "Initial module version";
-       //   ysver:version 0.1.0;
+       //   ys:version 0.1.0;
        // }
 
        //YANG module definition starts here
@@ -787,7 +787,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
            import example-module {
-             ysver:recommended-min-version 3.0.0;
+               ys:recommended-min-version 3.0.0;
            }
 
 4.2.  Import by YANG Semantic Version Rules
@@ -993,7 +993,7 @@ Internet-Draft                 YANG Semver                 February 2024
    module ietf-yang-semver {
      yang-version 1.1;
      namespace "urn:ietf:params:xml:ns:yang:ietf-yang-semver";
-     prefix ysver;
+   prefix ys;
 
      organization
        "IETF NETMOD (Network Modeling) Working Group";
@@ -1048,10 +1048,10 @@ Internet-Draft                 YANG Semver                 February 2024
      // and remove this note.
      // RFC Ed.: replace XXXX with actual RFC number and remove this
      // note.
-     // RFC Ed. update the ysver:version to "1.0.0".
+     // RFC Ed. update the ys:version to "1.0.0".
 
      revision 2024-01-22 {
-       ysver:version "1.0.0-draft-ietf-netmod-yang-semver-13";
+       ys:version "1.0.0-draft-ietf-netmod-yang-semver-13";
        description
          "Initial revision";
        reference
@@ -1262,7 +1262,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
       XML Namespace: urn:ietf:params:xml:ns:yang:ietf-yang-semver
 
-      Prefix: ysver
+      Prefix: ys
 
       Reference: [RFCXXXX]
 
@@ -1444,7 +1444,7 @@ Appendix A.  Example IETF Module Development
    group in the IETF.  Initially, this module is being developed in an
    individual internet draft, draft-jdoe-netmod-example-module.  The
    following represents the initial version tree (i.e., value of
-   ysver:version) of the module as it's being initially developed.
+   ys:version) of the module as it's being initially developed.
 
    Version lineage for initial module development:
 

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -4,16 +4,16 @@
 
 Network Working Group                                     J. Clarke, Ed.
 Internet-Draft                                            R. Wilton, Ed.
-Updates: 8407 (if approved)                          Cisco Systems, Inc.
+Updates: 8407, 8525, 7950 (if approved)              Cisco Systems, Inc.
 Intended status: Standards Track                               R. Rahman
-Expires: 25 August 2024                                          Equinix
+Expires: 2 September 2024                                        Equinix
                                                               B. Lengyel
                                                                 Ericsson
                                                                J. Sterne
                                                                    Nokia
                                                                B. Claise
                                                                   Huawei
-                                                        22 February 2024
+                                                            1 March 2024
 
 
                         YANG Semantic Versioning
@@ -25,7 +25,8 @@ Abstract
    applying an extended set of semantic versioning rules to revisions of
    YANG artifacts (e.g., modules and packages).  Additionally, this
    document defines a YANG extension for controlling module imports
-   based on these modified semantic versioning rules.
+   based on these modified semantic versioning rules.  This document
+   updates RFCs 7950, 8407, and 8525.
 
 Status of This Memo
 
@@ -42,7 +43,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 25 August 2024.
+   This Internet-Draft will expire on 2 September 2024.
 
 Copyright Notice
 
@@ -52,10 +53,9 @@ Copyright Notice
 
 
 
-
-Clarke, et al.           Expires 25 August 2024                 [Page 1]
+Clarke, et al.          Expires 2 September 2024                [Page 1]
 
-Internet-Draft                 YANG Semver                 February 2024
+Internet-Draft                 YANG Semver                    March 2024
 
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -74,7 +74,7 @@ Table of Contents
            Revisions . . . . . . . . . . . . . . . . . . . . . . . .   3
    3.  Terminology and Conventions . . . . . . . . . . . . . . . . .   4
    4.  YANG Semantic Versioning  . . . . . . . . . . . . . . . . . .   4
-     4.1.  Relationship Between SemVer and YANG Semver . . . . . . .   4
+     4.1.  Relationship Between SemVer and YANG Semver . . . . . . .   5
      4.2.  YANG Semantic Version Extension . . . . . . . . . . . . .   5
      4.3.  YANG Semver Pattern . . . . . . . . . . . . . . . . . . .   5
      4.4.  Semantic Versioning Scheme for YANG Artifacts . . . . . .   6
@@ -93,26 +93,30 @@ Table of Contents
      6.2.  YANG Semver in IETF Modules . . . . . . . . . . . . . . .  18
        6.2.1.  Guidelines for IETF Module Development  . . . . . . .  18
        6.2.2.  Guidelines for Published IETF Modules . . . . . . . .  19
-   7.  YANG Module . . . . . . . . . . . . . . . . . . . . . . . . .  19
-   8.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  22
-   9.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  23
-   10. Security Considerations . . . . . . . . . . . . . . . . . . .  23
-   11. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  24
-     11.1.  YANG Module Registrations  . . . . . . . . . . . . . . .  24
-     11.2.  Guidance for YANG Semver in IANA maintained YANG modules
-            and submodules . . . . . . . . . . . . . . . . . . . . .  24
-   12. References  . . . . . . . . . . . . . . . . . . . . . . . . .  25
-     12.1.  Normative References . . . . . . . . . . . . . . . . . .  25
-     12.2.  Informative References . . . . . . . . . . . . . . . . .  26
-   Appendix A.  Example IETF Module Development  . . . . . . . . . .  27
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  29
+   7.  Updates to ietf-yang-library  . . . . . . . . . . . . . . . .  19
+     7.1.  YANG library versioning augmentations . . . . . . . . . .  19
+       7.1.1.  Advertising version . . . . . . . . . . . . . . . . .  20
+   8.  YANG Modules  . . . . . . . . . . . . . . . . . . . . . . . .  20
+   9.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  26
+   10. Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  27
+   11. Security Considerations . . . . . . . . . . . . . . . . . . .  27
+   12. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  27
+     12.1.  YANG Module Registrations  . . . . . . . . . . . . . . .  28
+     12.2.  Guidance for YANG Semver in IANA maintained YANG modules
+            and submodules . . . . . . . . . . . . . . . . . . . . .  28
+   13. References  . . . . . . . . . . . . . . . . . . . . . . . . .  29
+     13.1.  Normative References . . . . . . . . . . . . . . . . . .  29
 
 
 
-Clarke, et al.           Expires 25 August 2024                 [Page 2]
+Clarke, et al.          Expires 2 September 2024                [Page 2]
 
-Internet-Draft                 YANG Semver                 February 2024
+Internet-Draft                 YANG Semver                    March 2024
 
+
+     13.2.  Informative References . . . . . . . . . . . . . . . . .  30
+   Appendix A.  Example IETF Module Development  . . . . . . . . . .  32
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  33
 
 1.  Introduction
 
@@ -132,7 +136,9 @@ Internet-Draft                 YANG Semver                 February 2024
    compatibility information for the YANG artifact without needing to
    compare or parse its body.  The version identifier and rules defined
    herein represent the RECOMMENDED approach to apply versioning to IETF
-   YANG artifacts.
+   YANG artifacts.  This document defines augmentations to ietf-yang-
+   library to reflect the version of YANG modules within the module-set
+   data.
 
    Note that a specific revision of the SemVer 2.0.0 specification is
    referenced here (from June 19, 2020) to provide an immutable version.
@@ -146,6 +152,23 @@ Internet-Draft                 YANG Semver                 February 2024
    and the YANG Semver version extension statement could be used:
 
    Example YANG module with branched revision history.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Clarke, et al.          Expires 2 September 2024                [Page 3]
+
+Internet-Draft                 YANG Semver                    March 2024
+
 
           Module revision date      Example version identifier
             2019-01-01                 <- 1.0.0
@@ -161,14 +184,6 @@ Internet-Draft                 YANG Semver                 February 2024
                         2019-06-01     <- 2.2.0
 
                                   Figure 1
-
-
-
-
-Clarke, et al.           Expires 25 August 2024                 [Page 3]
-
-Internet-Draft                 YANG Semver                 February 2024
-
 
    The tree diagram above illustrates how an example module's revision
    history might evolve, over time.
@@ -203,6 +218,14 @@ Internet-Draft                 YANG Semver                 February 2024
    changing an artifact's semantic version when its contents are
    updated.
 
+
+
+
+Clarke, et al.          Expires 2 September 2024                [Page 4]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
 4.1.  Relationship Between SemVer and YANG Semver
 
    [SemVer] is completely compatible with YANG Semver in that a SemVer
@@ -212,19 +235,6 @@ Internet-Draft                 YANG Semver                 February 2024
    YANG artifacts.  If no branching occurs within a YANG artifact (i.e.,
    you do not use the compatibility modifiers described below), the YANG
    Semver version label will appear as a SemVer version number.
-
-
-
-
-
-
-
-
-
-Clarke, et al.           Expires 25 August 2024                 [Page 4]
-
-Internet-Draft                 YANG Semver                 February 2024
-
 
 4.2.  YANG Semantic Version Extension
 
@@ -254,6 +264,24 @@ Internet-Draft                 YANG Semver                 February 2024
    *  COMPAT, if specified, MUST be either the literal string
       "compatible" or the literal string "non_compatible".
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+Clarke, et al.          Expires 2 September 2024                [Page 5]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
    Additionally, [SemVer] defines two specific types of metadata that
    may be appended to a semantic version string.  Pre-release metadata
    MAY be appended to a YANG Semver string after a trailing '-'
@@ -271,16 +299,6 @@ Internet-Draft                 YANG Semver                 February 2024
    extension to apply a YANG Semver identifier to a YANG artifact as
    well as a typedef that formally specifies the syntax of the YANG
    Semver.
-
-
-
-
-
-
-Clarke, et al.           Expires 25 August 2024                 [Page 5]
-
-Internet-Draft                 YANG Semver                 February 2024
-
 
 4.4.  Semantic Versioning Scheme for YANG Artifacts
 
@@ -311,6 +329,15 @@ Internet-Draft                 YANG Semver                 February 2024
       semantic versioning scheme are exactly the same as those defined
       by the [SemVer] versioning scheme.
 
+
+
+
+
+Clarke, et al.          Expires 2 September 2024                [Page 6]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
    Every YANG module and submodule versioned using the YANG semantic
    versioning scheme specifies the module's or submodule's semantic
    version as the argument to the 'ys:version' statement.
@@ -328,15 +355,6 @@ Internet-Draft                 YANG Semver                 February 2024
 
    As stated above, the YANG semantic version is expressed as a string
    of the form: 'X.Y.Z_COMPAT'.
-
-
-
-
-
-Clarke, et al.           Expires 25 August 2024                 [Page 6]
-
-Internet-Draft                 YANG Semver                 February 2024
-
 
    *  'X' is the MAJOR version.  Changes in the MAJOR version number
       indicate changes that are non-backwards-compatible to versions
@@ -368,6 +386,14 @@ Internet-Draft                 YANG Semver                 February 2024
       same MAJOR and MINOR version numbers, but lower PATCH version
       number, depending on what form modifier '_COMPAT' takes:
 
+
+
+
+Clarke, et al.          Expires 2 September 2024                [Page 7]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
       -  If the modifier string is absent, the change represents an
          editorial change.
 
@@ -386,14 +412,6 @@ Internet-Draft                 YANG Semver                 February 2024
    will also have a modifier.  The modifier can change from
    "_compatible" to "_non_compatible" in a subsequent version, but the
    modifier MUST NOT change from "_non_compatible" to "_compatible" and
-
-
-
-Clarke, et al.           Expires 25 August 2024                 [Page 7]
-
-Internet-Draft                 YANG Semver                 February 2024
-
-
    MUST NOT be removed.  The persistence of the "_non_compatible"
    modifier ensures that comparisons of versions do not give the false
    impression of compatibility between two potentially non-compatible
@@ -424,6 +442,14 @@ Internet-Draft                 YANG Semver                 February 2024
    For example, the following branching approach using the following
    YANG Semver identifiers is not supported:
 
+
+
+
+Clarke, et al.          Expires 2 September 2024                [Page 8]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
          3.5.0 -- 3.6.0 (add leaf foo)
            |
            |
@@ -437,18 +463,6 @@ Internet-Draft                 YANG Semver                 February 2024
    Note that this type of branching, where two versions on the same
    branch have different backwards compatible changes is allowed in
    [I-D.ietf-netmod-yang-module-versioning].
-
-
-
-
-
-
-
-
-Clarke, et al.           Expires 25 August 2024                 [Page 8]
-
-Internet-Draft                 YANG Semver                 February 2024
-
 
 4.4.2.  YANG Semver with submodules
 
@@ -484,27 +498,15 @@ Internet-Draft                 YANG Semver                 February 2024
    The following diagram and explanation illustrate how YANG semantic
    versions work.
 
-   YANG Semantic versions for an example module:
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-Clarke, et al.           Expires 25 August 2024                 [Page 9]
+Clarke, et al.          Expires 2 September 2024                [Page 9]
 
-Internet-Draft                 YANG Semver                 February 2024
+Internet-Draft                 YANG Semver                    March 2024
 
+
+   YANG Semantic versions for an example module:
 
             0.1.0
               |
@@ -555,11 +557,9 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-
-
-Clarke, et al.           Expires 25 August 2024                [Page 10]
+Clarke, et al.          Expires 2 September 2024               [Page 10]
 
-Internet-Draft                 YANG Semver                 February 2024
+Internet-Draft                 YANG Semver                    March 2024
 
 
       1.3.1_non_compatible - backport NBC fix, rename "baz" to "bar"
@@ -613,9 +613,9 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 25 August 2024                [Page 11]
+Clarke, et al.          Expires 2 September 2024               [Page 11]
 
-Internet-Draft                 YANG Semver                 February 2024
+Internet-Draft                 YANG Semver                    March 2024
 
 
    3.  If an artifact is being updated in an editorial way, then the
@@ -669,9 +669,9 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 25 August 2024                [Page 12]
+Clarke, et al.          Expires 2 September 2024               [Page 12]
 
-Internet-Draft                 YANG Semver                 February 2024
+Internet-Draft                 YANG Semver                    March 2024
 
 
    [I-D.ietf-netmod-yang-module-versioning] defines the "rev:non-
@@ -725,9 +725,9 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 25 August 2024                [Page 13]
+Clarke, et al.          Expires 2 September 2024               [Page 13]
 
-Internet-Draft                 YANG Semver                 February 2024
+Internet-Draft                 YANG Semver                    March 2024
 
 
        revision 2017-02-07 {
@@ -781,9 +781,9 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 25 August 2024                [Page 14]
+Clarke, et al.          Expires 2 September 2024               [Page 14]
 
-Internet-Draft                 YANG Semver                 February 2024
+Internet-Draft                 YANG Semver                    March 2024
 
 
    {
@@ -837,9 +837,9 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 25 August 2024                [Page 15]
+Clarke, et al.          Expires 2 September 2024               [Page 15]
 
-Internet-Draft                 YANG Semver                 February 2024
+Internet-Draft                 YANG Semver                    March 2024
 
 
            import example-module {
@@ -893,9 +893,9 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 25 August 2024                [Page 16]
+Clarke, et al.          Expires 2 September 2024               [Page 16]
 
-Internet-Draft                 YANG Semver                 February 2024
+Internet-Draft                 YANG Semver                    March 2024
 
 
    Development of a brand new YANG module or submodule outside of the
@@ -949,9 +949,9 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 25 August 2024                [Page 17]
+Clarke, et al.          Expires 2 September 2024               [Page 17]
 
-Internet-Draft                 YANG Semver                 February 2024
+Internet-Draft                 YANG Semver                    March 2024
 
 
    both versions (e.g., 2.0.0-alpha.3 becomes 1.1.0-alpha.4).  However,
@@ -1005,9 +1005,9 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 25 August 2024                [Page 18]
+Clarke, et al.          Expires 2 September 2024               [Page 18]
 
-Internet-Draft                 YANG Semver                 February 2024
+Internet-Draft                 YANG Semver                    March 2024
 
 
    followed by the document's revision (e.g., 2.0.0-draft-user-netmod-
@@ -1040,12 +1040,61 @@ Internet-Draft                 YANG Semver                 February 2024
    1.2.0 (since 1.0.0 would have been the initial, pre-NMDA release, and
    1.1.0 would have been the NMDA revision).
 
-7.  YANG Module
+7.  Updates to ietf-yang-library
+
+   This document updates YANG 1.1 [RFC7950] and YANG library [RFC8525]
+   to clarify how ambiguous module imports are resolved.  It also
+   defines the YANG module, ietf-yang-library-semver, that augments YANG
+   library [RFC8525] with a version leaf for modules and submodules.
+
+7.1.  YANG library versioning augmentations
+
+
+   The "ietf-yang-library-semver" YANG module has the following
+   structure (using the notation defined in [RFC8340]):
+
+
+
+
+
+
+
+
+
+Clarke, et al.          Expires 2 September 2024               [Page 19]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
+   module: ietf-yang-library-semver
+
+     augment /yanglib:yang-library/yanglib:module-set/yanglib:module:
+       +--ro version?   ys:version
+     augment /yanglib:yang-library/yanglib:module-set/yanglib:module
+               /yanglib:submodule:
+       +--ro version?   ys:version
+     augment /yanglib:yang-library/yanglib:module-set
+               /yanglib:import-only-module:
+       +--ro version?   ys:version
+     augment /yanglib:yang-library/yanglib:module-set
+               /yanglib:import-only-module/yanglib:submodule:
+       +--ro version?   ys:version
+
+                                  Figure 3
+
+7.1.1.  Advertising version
+
+   The ietf-yang-library-semver YANG module augments the "module" and
+   "submodule" lists in ietf-yang-library with "version" leafs to
+   optionally declare the version identifier associated with each module
+   and submodule.
+
+8.  YANG Modules
 
    This YANG module contains the typedef for the YANG semantic version
    and the identity to signal its use.
 
-   <CODE BEGINS> file "ietf-yang-semver@2024-01-22.yang"
+   <CODE BEGINS> file "ietf-yang-semver@2024-03-01.yang"
    module ietf-yang-semver {
      yang-version 1.1;
      namespace "urn:ietf:params:xml:ns:yang:ietf-yang-semver";
@@ -1058,14 +1107,6 @@ Internet-Draft                 YANG Semver                 February 2024
         WG List:  <mailto:netmod@ietf.org>
 
         Author:   Joe Clarke
-
-
-
-Clarke, et al.           Expires 25 August 2024                [Page 19]
-
-Internet-Draft                 YANG Semver                 February 2024
-
-
                   <mailto:jclarke@cisco.com>
         Author:   Robert Wilton
                   <mailto:rwilton@cisco.com>
@@ -1073,6 +1114,14 @@ Internet-Draft                 YANG Semver                 February 2024
                   <mailto:reshad@yahoo.com>
         Author:   Balazs Lengyel
                   <mailto:balazs.lengyel@ericsson.com>
+
+
+
+Clarke, et al.          Expires 2 September 2024               [Page 20]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
         Author:   Jason Sterne
                   <mailto:jason.sterne@nokia.com>
         Author:   Benoit Claise
@@ -1114,14 +1163,6 @@ Internet-Draft                 YANG Semver                 February 2024
          "RFC XXXX: YANG Semantic Versioning.";
      }
 
-
-
-
-Clarke, et al.           Expires 25 August 2024                [Page 20]
-
-Internet-Draft                 YANG Semver                 February 2024
-
-
      /*
       * Extensions
       */
@@ -1129,6 +1170,14 @@ Internet-Draft                 YANG Semver                 February 2024
      extension version {
        argument yang-semantic-version;
        description
+
+
+
+Clarke, et al.          Expires 2 September 2024               [Page 21]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
          "The version extension can be used to provide an additional
           identifier associated with a module or submodule
           revision.
@@ -1170,14 +1219,6 @@ Internet-Draft                 YANG Semver                 February 2024
           standardized.
 
           If specified multiple times, then any module revision that
-
-
-
-Clarke, et al.           Expires 25 August 2024                [Page 21]
-
-Internet-Draft                 YANG Semver                 February 2024
-
-
           satisfies at least one of the 'recommended-min-version'
           statements is an acceptable recommended version for
           import.
@@ -1185,6 +1226,13 @@ Internet-Draft                 YANG Semver                 February 2024
           A particular version of an imported module adheres to an
           import's 'recommended-min-version' extension statement if one
           of the following conditions are met:
+
+
+
+Clarke, et al.          Expires 2 September 2024               [Page 22]
+
+Internet-Draft                 YANG Semver                    March 2024
+
 
           * Has the same MAJOR and MINOR version numbers and same or
             greater PATCH number.
@@ -1219,20 +1267,182 @@ Internet-Draft                 YANG Semver                 February 2024
    }
    <CODE ENDS>
 
-8.  Contributors
+   This YANG module contains the augmentations to the ietf-yang-library.
+
+   <CODE BEGINS> file "ietf-yang-library-semver@2024-03-01.yang"
+   module ietf-yang-library-semver {
+     yang-version 1.1;
+     namespace
+       "urn:ietf:params:xml:ns:yang:ietf-yang-library-semver";
+     prefix yl-rev;
+
+     import ietf-yang-semver {
+       prefix ys;
+       reference
+         "XXXX: YANG Semantic Versioning";
+     }
+     import ietf-yang-library {
+
+
+
+Clarke, et al.          Expires 2 September 2024               [Page 23]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
+       prefix yanglib;
+       reference
+         "RFC 8525: YANG Library";
+     }
+
+     organization
+       "IETF NETMOD (Network Modeling) Working Group";
+     contact
+       "WG Web:   <https://datatracker.ietf.org/wg/netmod/>
+        WG List:  <mailto:netmod@ietf.org>
+
+        Author:   Joe Clarke
+                  <mailto:jclarke@cisco.com>
+
+        Author:   Reshad Rahman
+                  <mailto:reshad@yahoo.com>
+
+        Author:   Robert Wilton
+                  <mailto:rwilton@cisco.com>
+
+        Author:   Balazs Lengyel
+                  <mailto:balazs.lengyel@ericsson.com>
+
+        Author:   Jason Sterne
+                  <mailto:jason.sterne@nokia.com>";
+     description
+       "This module contains augmentations to YANG Library to add module
+        and submodule level version identifiers.
+
+        Copyright (c) 2024 IETF Trust and the persons identified as
+        authors of the code.  All rights reserved.
+
+        Redistribution and use in source and binary forms, with or
+        without modification, is permitted pursuant to, and subject
+        to the license terms contained in, the Revised BSD License
+        set forth in Section 4.c of the IETF Trust's Legal Provisions
+        Relating to IETF Documents
+        (http://trustee.ietf.org/license-info).
+
+        This version of this YANG module is part of RFC XXXX; see
+        the RFC itself for full legal notices.
+
+        The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+        NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+        'MAY', and 'OPTIONAL' in this document are to be interpreted as
+        described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+        they appear in all capitals, as shown here.";
+
+
+
+
+Clarke, et al.          Expires 2 September 2024               [Page 24]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
+     // RFC Ed.: update the date below with the date of RFC publication
+     // and remove this note.
+     // RFC Ed.: replace XXXX (including in the imports above) with
+     // actual RFC number and remove this note.
+     // RFC Ed.: please replace ys:version with 1.0.0 and
+     // remove this note.
+
+     revision 2024-03-01 {
+       ys:version "1.0.0-draft-ietf-netmod-yang-semver-13";
+       description
+         "Initial revision";
+       reference
+         "XXXX: YANG Semantic Versioning";
+     }
+
+     // library 1.0 modules-state is not augmented with version
+
+     augment "/yanglib:yang-library/yanglib:module-set/yanglib:module" {
+       description
+         "Add a version to module information";
+       leaf version {
+         type ys:version;
+         description
+           "The version associated with this module revision.
+            The value MUST match the version value in the
+            specific revision of the module loaded in this module-set.";
+         reference
+           "XXXX: YANG Semantic Versioning;
+            Section 7.1.1, Advertising version";
+       }
+     }
+
+     augment
+       "/yanglib:yang-library/yanglib:module-set/yanglib:module/"
+     + "yanglib:submodule" {
+       description
+         "Add a version to submodule information";
+       leaf version {
+         type ys:version;
+         description
+           "The version associated with this submodule revision.
+            The value MUST match the version value in the
+            specific revision of the submodule included by the module
+            loaded in this module-set.";
+         reference
+           "XXXX: YANG Semantic Versioning;
+            Section 7.1.1, Advertising version";
+       }
+
+
+
+Clarke, et al.          Expires 2 September 2024               [Page 25]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
+     }
+
+     augment "/yanglib:yang-library/yanglib:module-set/"
+           + "yanglib:import-only-module" {
+       description
+         "Add a version to module information";
+       leaf version {
+         type ys:version;
+         description
+           "The version associated with this module revision.
+            The value MUST match the version value in the
+            specific revision of the module included in this
+            module-set.";
+         reference
+           "XXXX: YANG Semantic Versioning;
+            Section 7.1.1, Advertising version";
+       }
+     }
+
+     augment "/yanglib:yang-library/yanglib:module-set/"
+           + "yanglib:import-only-module/yanglib:submodule" {
+       description
+         "Add a version to submodule information";
+       leaf version {
+         type ys:version;
+         description
+           "The version associated with this submodule revision.
+            The value MUST match the version value in the specific
+            revision of the submodule included by the import-only-module
+            loaded in this module-set.";
+         reference
+           "XXXX: Updated YANG Module Revision Handling;
+            Section 7.1.1, Advertising version";
+       }
+     }
+   }
+   <CODE ENDS>
+
+9.  Contributors
 
    The following people made substantial contributions to this document:
-
-
-
-
-
-
-
-Clarke, et al.           Expires 25 August 2024                [Page 22]
-
-Internet-Draft                 YANG Semver                 February 2024
-
 
      Bo Wu
      lana.wubo@huawei.com
@@ -1241,9 +1451,16 @@ Internet-Draft                 YANG Semver                 February 2024
      jlindbla@cisco.com
 
 
-                                  Figure 3
 
-9.  Acknowledgments
+
+Clarke, et al.          Expires 2 September 2024               [Page 26]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
+                                  Figure 4
+
+10.  Acknowledgments
 
    This document grew out of the YANG module versioning design team that
    started after IETF 101.  The team consists of the following members
@@ -1265,7 +1482,7 @@ Internet-Draft                 YANG Semver                 February 2024
    We would also like to thank Joseph Donahue from the SemVer.org
    project for his input on SemVer use and overall document readability.
 
-10.  Security Considerations
+11.  Security Considerations
 
    The YANG module specified in this document defines a schema for data
    that is designed to be accessed via network management protocols such
@@ -1280,23 +1497,24 @@ Internet-Draft                 YANG Semver                 February 2024
    preconfigured subset of all available NETCONF or RESTCONF protocol
    operations and content.
 
-
-
-
-
-
-Clarke, et al.           Expires 25 August 2024                [Page 23]
-
-Internet-Draft                 YANG Semver                 February 2024
-
-
    That said, the YANG module in this document does not define any
    writeable nodes.  The extensions defined are only used to document
    YANG artifacts.
 
-11.  IANA Considerations
+12.  IANA Considerations
 
-11.1.  YANG Module Registrations
+
+
+
+
+
+
+Clarke, et al.          Expires 2 September 2024               [Page 27]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
+12.1.  YANG Module Registrations
 
    This document requests IANA to register a URI in the "IETF XML
    Registry" [RFC3688].  Following the format in RFC 3688, the following
@@ -1322,7 +1540,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
       Reference: [RFCXXXX]
 
-11.2.  Guidance for YANG Semver in IANA maintained YANG modules and
+12.2.  Guidance for YANG Semver in IANA maintained YANG modules and
        submodules
 
    Note for IANA (to be removed by the RFC editor): Please check that
@@ -1339,15 +1557,18 @@ Internet-Draft                 YANG Semver                 February 2024
    Semver version identifier for all new revisions, as defined in
    Section 4.
 
-
-
-Clarke, et al.           Expires 25 August 2024                [Page 24]
-
-Internet-Draft                 YANG Semver                 February 2024
-
-
    The YANG Semver version associated with the new revision MUST follow
    the rules defined in Section 4.5.
+
+
+
+
+
+
+Clarke, et al.          Expires 2 September 2024               [Page 28]
+
+Internet-Draft                 YANG Semver                    March 2024
+
 
    Note: For IANA maintained YANG modules and submodules that have
    already been published, versions MUST be retroactively applied to all
@@ -1367,9 +1588,9 @@ Internet-Draft                 YANG Semver                 February 2024
    "_compatible" or "_non_compatible" modifiers to the "Z_COMPAT"
    version element.
 
-12.  References
+13.  References
 
-12.1.  Normative References
+13.1.  Normative References
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
@@ -1394,27 +1615,31 @@ Internet-Draft                 YANG Semver                 February 2024
               DOI 10.17487/RFC8407, October 2018,
               <https://www.rfc-editor.org/info/rfc8407>.
 
-
-
-
-Clarke, et al.           Expires 25 August 2024                [Page 25]
-
-Internet-Draft                 YANG Semver                 February 2024
-
-
    [RFC7950]  Bjorklund, M., Ed., "The YANG 1.1 Data Modeling Language",
               RFC 7950, DOI 10.17487/RFC7950, August 2016,
               <https://www.rfc-editor.org/info/rfc7950>.
+
+
+
+Clarke, et al.          Expires 2 September 2024               [Page 29]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
+   [RFC8525]  Bierman, A., Bjorklund, M., Schoenwaelder, J., Watsen, K.,
+              and R. Wilton, "YANG Library", RFC 8525,
+              DOI 10.17487/RFC8525, March 2019,
+              <https://www.rfc-editor.org/info/rfc8525>.
 
    [I-D.ietf-netmod-yang-module-versioning]
               Wilton, R., Rahman, R., Lengyel, B., Clarke, J., and J.
               Sterne, "Updated YANG Module Revision Handling", Work in
               Progress, Internet-Draft, draft-ietf-netmod-yang-module-
-              versioning-10, 17 October 2023,
-              <https://datatracker.ietf.org/doc/html/draft-ietf-netmod-
-              yang-module-versioning-10>.
+              versioning-11, 1 March 2024,
+              <https://datatracker.ietf.org/api/v1/doc/document/draft-
+              ietf-netmod-yang-module-versioning/>.
 
-12.2.  Informative References
+13.2.  Informative References
 
    [I-D.clacla-netmod-yang-model-update]
               Claise, B., Clarke, J., Lengyel, B., and K. D'Souza, "New
@@ -1437,10 +1662,25 @@ Internet-Draft                 YANG Semver                 February 2024
               <https://datatracker.ietf.org/doc/html/draft-ietf-netmod-
               yang-schema-comparison-02>.
 
+   [RFC8340]  Bjorklund, M. and L. Berger, Ed., "YANG Tree Diagrams",
+              BCP 215, RFC 8340, DOI 10.17487/RFC8340, March 2018,
+              <https://www.rfc-editor.org/info/rfc8340>.
+
    [RFC8342]  Bjorklund, M., Schoenwaelder, J., Shafer, P., Watsen, K.,
               and R. Wilton, "Network Management Datastore Architecture
               (NMDA)", RFC 8342, DOI 10.17487/RFC8342, March 2018,
               <https://www.rfc-editor.org/info/rfc8342>.
+
+
+
+
+
+
+
+Clarke, et al.          Expires 2 September 2024               [Page 30]
+
+Internet-Draft                 YANG Semver                    March 2024
+
 
    [RFC6241]  Enns, R., Ed., Bjorklund, M., Ed., Schoenwaelder, J., Ed.,
               and A. Bierman, Ed., "Network Configuration Protocol
@@ -1450,13 +1690,6 @@ Internet-Draft                 YANG Semver                 February 2024
    [RFC6242]  Wasserman, M., "Using the NETCONF Protocol over Secure
               Shell (SSH)", RFC 6242, DOI 10.17487/RFC6242, June 2011,
               <https://www.rfc-editor.org/info/rfc6242>.
-
-
-
-Clarke, et al.           Expires 25 August 2024                [Page 26]
-
-Internet-Draft                 YANG Semver                 February 2024
-
 
    [RFC8040]  Bierman, A., Bjorklund, M., and K. Watsen, "RESTCONF
               Protocol", RFC 8040, DOI 10.17487/RFC8040, January 2017,
@@ -1494,6 +1727,17 @@ Internet-Draft                 YANG Semver                 February 2024
               <https://www.iana.org/assignments/iana-routing-types/iana-
               routing-types.xhtml>.
 
+
+
+
+
+
+
+Clarke, et al.          Expires 2 September 2024               [Page 31]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
 Appendix A.  Example IETF Module Development
 
    Assume a new YANG module is being developed in the netmod working
@@ -1503,16 +1747,6 @@ Appendix A.  Example IETF Module Development
    ys:version) of the module as it's being initially developed.
 
    Version lineage for initial module development:
-
-
-
-
-
-
-Clarke, et al.           Expires 25 August 2024                [Page 27]
-
-Internet-Draft                 YANG Semver                 February 2024
-
 
          0.0.1-draft-jdoe-netmod-example-module-00
            |
@@ -1552,6 +1786,14 @@ Internet-Draft                 YANG Semver                 February 2024
 
    In parallel with (track 2):
 
+
+
+
+Clarke, et al.          Expires 2 September 2024               [Page 32]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
          1.1.0-draft-asmith-netmod-exmod-changes-00
            |
          1.1.0-draft-asmith-netmod-exmod-changes-01
@@ -1559,16 +1801,6 @@ Internet-Draft                 YANG Semver                 February 2024
    At this point, the WG decides to merge some aspects of both and adopt
    the work in asmith's draft as draft-ietf-netmod-exmod-changes.  A
    single version progression continues.
-
-
-
-
-
-
-Clarke, et al.           Expires 25 August 2024                [Page 28]
-
-Internet-Draft                 YANG Semver                 February 2024
-
 
          1.1.0-draft-ietf-netmod-exmod-changes-00
            |
@@ -1610,6 +1842,14 @@ Authors' Addresses
    Email: balazs.lengyel@ericsson.com
 
 
+
+
+
+Clarke, et al.          Expires 2 September 2024               [Page 33]
+
+Internet-Draft                 YANG Semver                    March 2024
+
+
    Jason Sterne
    Nokia
    Email: jason.sterne@nokia.com
@@ -1621,4 +1861,44 @@ Authors' Addresses
 
 
 
-Clarke, et al.           Expires 25 August 2024                [Page 29]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Clarke, et al.          Expires 2 September 2024               [Page 34]

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -1049,7 +1049,7 @@ Internet-Draft                 YANG Semver                 February 2024
    module ietf-yang-semver {
      yang-version 1.1;
      namespace "urn:ietf:params:xml:ns:yang:ietf-yang-semver";
-   prefix ys;
+     prefix ys;
 
      organization
        "IETF NETMOD (Network Modeling) Working Group";

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -1129,7 +1129,7 @@ Internet-Draft                 YANG Semver                 February 2024
      extension version {
        argument yang-semantic-version;
        description
-         "The version can be used to provide an additional
+         "The version extension can be used to provide an additional
           identifier associated with a module or submodule
           revision.
 
@@ -1160,8 +1160,8 @@ Internet-Draft                 YANG Semver                 February 2024
          "Recommends the versions of the module that may be imported to
           one that is greater than or equal to the specified version.
 
-          The argument value MUST conform to the
-          'version' typedef defined in this module.
+          The format of the recommended-min-version extension argument
+          MUST conform to the 'version' typedef defined in this module.
 
           The statement MUST only be a substatement of the import
           statement.  Zero, one or more 'recommended-min-version'

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -6,14 +6,14 @@ Network Working Group                                     J. Clarke, Ed.
 Internet-Draft                                            R. Wilton, Ed.
 Updates: 8407 (if approved)                          Cisco Systems, Inc.
 Intended status: Standards Track                               R. Rahman
-Expires: 23 August 2024                                          Equinix
+Expires: 24 August 2024                                          Equinix
                                                               B. Lengyel
                                                                 Ericsson
                                                                J. Sterne
                                                                    Nokia
                                                                B. Claise
                                                                   Huawei
-                                                        20 February 2024
+                                                        21 February 2024
 
 
                         YANG Semantic Versioning
@@ -21,11 +21,11 @@ Expires: 23 August 2024                                          Equinix
 
 Abstract
 
-   This document specifies a YANG extension along with guidelines
-   guidelines for applying an extended set of semantic versioning rules
-   to revisions of YANG artifacts (e.g., modules and packages).
-   Additionally, this document defines a YANG extension for controlling
-   module imports based on these modified semantic versioning rules.
+   This document specifies a YANG extension along with guidelines for
+   applying an extended set of semantic versioning rules to revisions of
+   YANG artifacts (e.g., modules and packages).  Additionally, this
+   document defines a YANG extension for controlling module imports
+   based on these modified semantic versioning rules.
 
 Status of This Memo
 
@@ -42,7 +42,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 23 August 2024.
+   This Internet-Draft will expire on 24 August 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Clarke, et al.           Expires 23 August 2024                 [Page 1]
+Clarke, et al.           Expires 24 August 2024                 [Page 1]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Clarke, et al.           Expires 23 August 2024                 [Page 2]
+Clarke, et al.           Expires 24 August 2024                 [Page 2]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -165,7 +165,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                 [Page 3]
+Clarke, et al.           Expires 24 August 2024                 [Page 3]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -221,7 +221,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                 [Page 4]
+Clarke, et al.           Expires 24 August 2024                 [Page 4]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -229,7 +229,7 @@ Internet-Draft                 YANG Semver                 February 2024
 4.2.  YANG Semantic Version Extension
 
    The ietf-yang-semver module defines a "version" extension -- a
-   substatement to a module or submodule's "import" statement -- that
+   substatement to a module or submodule's "revision" statement -- that
    takes a YANG semantic version as its argument and specified the
    version for the given module or submodule.  The syntax for the YANG
    semantic version is defined in a typedef in the same module and
@@ -277,7 +277,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                 [Page 5]
+Clarke, et al.           Expires 24 August 2024                 [Page 5]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -333,7 +333,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                 [Page 6]
+Clarke, et al.           Expires 24 August 2024                 [Page 6]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -389,7 +389,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                 [Page 7]
+Clarke, et al.           Expires 24 August 2024                 [Page 7]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -445,7 +445,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                 [Page 8]
+Clarke, et al.           Expires 24 August 2024                 [Page 8]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -501,7 +501,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                 [Page 9]
+Clarke, et al.           Expires 24 August 2024                 [Page 9]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -557,7 +557,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 10]
+Clarke, et al.           Expires 24 August 2024                [Page 10]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -613,7 +613,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 11]
+Clarke, et al.           Expires 24 August 2024                [Page 11]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -669,7 +669,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 12]
+Clarke, et al.           Expires 24 August 2024                [Page 12]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -725,7 +725,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 13]
+Clarke, et al.           Expires 24 August 2024                [Page 13]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -781,7 +781,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 14]
+Clarke, et al.           Expires 24 August 2024                [Page 14]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -837,7 +837,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 15]
+Clarke, et al.           Expires 24 August 2024                [Page 15]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -893,7 +893,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 16]
+Clarke, et al.           Expires 24 August 2024                [Page 16]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -949,7 +949,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 17]
+Clarke, et al.           Expires 24 August 2024                [Page 17]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1005,7 +1005,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 18]
+Clarke, et al.           Expires 24 August 2024                [Page 18]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1061,7 +1061,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 19]
+Clarke, et al.           Expires 24 August 2024                [Page 19]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1117,7 +1117,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 20]
+Clarke, et al.           Expires 24 August 2024                [Page 20]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1173,7 +1173,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 21]
+Clarke, et al.           Expires 24 August 2024                [Page 21]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1229,7 +1229,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 22]
+Clarke, et al.           Expires 24 August 2024                [Page 22]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1285,7 +1285,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 23]
+Clarke, et al.           Expires 24 August 2024                [Page 23]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1341,7 +1341,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 24]
+Clarke, et al.           Expires 24 August 2024                [Page 24]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1397,7 +1397,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 25]
+Clarke, et al.           Expires 24 August 2024                [Page 25]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1453,7 +1453,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 26]
+Clarke, et al.           Expires 24 August 2024                [Page 26]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1509,7 +1509,7 @@ Appendix A.  Example IETF Module Development
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 27]
+Clarke, et al.           Expires 24 August 2024                [Page 27]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1565,7 +1565,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 28]
+Clarke, et al.           Expires 24 August 2024                [Page 28]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1621,4 +1621,4 @@ Authors' Addresses
 
 
 
-Clarke, et al.           Expires 23 August 2024                [Page 29]
+Clarke, et al.           Expires 24 August 2024                [Page 29]

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -1269,7 +1269,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
    This YANG module contains the augmentations to the ietf-yang-library.
 
-   <CODE BEGINS> file "ietf-yang-library-semver@2024-03-01.yang"
+   <CODE BEGINS> file "ietf-yang-library-semver@2024-03-02.yang"
    module ietf-yang-library-semver {
      yang-version 1.1;
      namespace
@@ -1353,8 +1353,8 @@ Internet-Draft                 YANG Semver                    March 2024
      // RFC Ed.: please replace ys:version with 1.0.0 and
      // remove this note.
 
-     revision 2024-03-01 {
-       ys:version "1.0.0-draft-ietf-netmod-yang-semver-13";
+     revision 2024-03-02 {
+       ys:version "1.0.0-draft-ietf-netmod-yang-semver-14";
        description
          "Initial revision";
        reference

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -6,14 +6,14 @@ Network Working Group                                     J. Clarke, Ed.
 Internet-Draft                                            R. Wilton, Ed.
 Updates: 8407 (if approved)                          Cisco Systems, Inc.
 Intended status: Standards Track                               R. Rahman
-Expires: 16 August 2024                                        Graphiant
+Expires: 23 August 2024                                          Equinix
                                                               B. Lengyel
                                                                 Ericsson
                                                                J. Sterne
                                                                    Nokia
                                                                B. Claise
                                                                   Huawei
-                                                        13 February 2024
+                                                        20 February 2024
 
 
                         YANG Semantic Versioning
@@ -42,7 +42,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 16 August 2024.
+   This Internet-Draft will expire on 23 August 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Clarke, et al.           Expires 16 August 2024                 [Page 1]
+Clarke, et al.           Expires 23 August 2024                 [Page 1]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Clarke, et al.           Expires 16 August 2024                 [Page 2]
+Clarke, et al.           Expires 23 August 2024                 [Page 2]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -165,7 +165,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                 [Page 3]
+Clarke, et al.           Expires 23 August 2024                 [Page 3]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -221,7 +221,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                 [Page 4]
+Clarke, et al.           Expires 23 August 2024                 [Page 4]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -277,7 +277,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                 [Page 5]
+Clarke, et al.           Expires 23 August 2024                 [Page 5]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -333,7 +333,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                 [Page 6]
+Clarke, et al.           Expires 23 August 2024                 [Page 6]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -389,7 +389,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                 [Page 7]
+Clarke, et al.           Expires 23 August 2024                 [Page 7]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -445,7 +445,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                 [Page 8]
+Clarke, et al.           Expires 23 August 2024                 [Page 8]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -501,7 +501,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                 [Page 9]
+Clarke, et al.           Expires 23 August 2024                 [Page 9]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -557,7 +557,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                [Page 10]
+Clarke, et al.           Expires 23 August 2024                [Page 10]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -613,7 +613,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                [Page 11]
+Clarke, et al.           Expires 23 August 2024                [Page 11]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -669,7 +669,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                [Page 12]
+Clarke, et al.           Expires 23 August 2024                [Page 12]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -725,7 +725,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                [Page 13]
+Clarke, et al.           Expires 23 August 2024                [Page 13]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -781,7 +781,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                [Page 14]
+Clarke, et al.           Expires 23 August 2024                [Page 14]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -837,7 +837,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                [Page 15]
+Clarke, et al.           Expires 23 August 2024                [Page 15]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -893,7 +893,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                [Page 16]
+Clarke, et al.           Expires 23 August 2024                [Page 16]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -949,7 +949,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                [Page 17]
+Clarke, et al.           Expires 23 August 2024                [Page 17]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1005,7 +1005,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                [Page 18]
+Clarke, et al.           Expires 23 August 2024                [Page 18]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1061,7 +1061,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                [Page 19]
+Clarke, et al.           Expires 23 August 2024                [Page 19]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1117,7 +1117,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                [Page 20]
+Clarke, et al.           Expires 23 August 2024                [Page 20]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1173,7 +1173,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                [Page 21]
+Clarke, et al.           Expires 23 August 2024                [Page 21]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1229,7 +1229,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                [Page 22]
+Clarke, et al.           Expires 23 August 2024                [Page 22]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1285,7 +1285,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                [Page 23]
+Clarke, et al.           Expires 23 August 2024                [Page 23]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1341,7 +1341,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                [Page 24]
+Clarke, et al.           Expires 23 August 2024                [Page 24]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1397,7 +1397,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                [Page 25]
+Clarke, et al.           Expires 23 August 2024                [Page 25]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1453,7 +1453,7 @@ Appendix A.  Example IETF Module Development
 
 
 
-Clarke, et al.           Expires 16 August 2024                [Page 26]
+Clarke, et al.           Expires 23 August 2024                [Page 26]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1509,7 +1509,7 @@ Internet-Draft                 YANG Semver                 February 2024
 
 
 
-Clarke, et al.           Expires 16 August 2024                [Page 27]
+Clarke, et al.           Expires 23 August 2024                [Page 27]
 
 Internet-Draft                 YANG Semver                 February 2024
 
@@ -1541,7 +1541,7 @@ Authors' Addresses
 
 
    Reshad Rahman
-   Graphiant
+   Equinix
    Email: reshad@yahoo.com
 
 
@@ -1565,4 +1565,4 @@ Authors' Addresses
 
 
 
-Clarke, et al.           Expires 16 August 2024                [Page 28]
+Clarke, et al.           Expires 23 August 2024                [Page 28]

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" updates="8407,8525,7950" category="std" ipr="trust200902" consensus="true" docName="draft-ietf-netmod-yang-semver-13" xml:lang="en" obsoletes="" submissionType="IETF" version="3">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" updates="8407,8525,7950" category="std" ipr="trust200902" consensus="true" docName="draft-ietf-netmod-yang-semver-14" xml:lang="en" obsoletes="" submissionType="IETF" version="3">
   <front>
     <title abbrev="YANG Semver">YANG Semantic Versioning</title>
 <seriesInfo name="Internet-Draft" value="draft-ietf-netmod-yang-semver-14"/>

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -183,7 +183,7 @@ of the artifact only, then the version identifiers used by the YANG
 </ul>
 <t>Every YANG module and submodule versioned using the YANG semantic versioning
     scheme specifies the module's or submodule's semantic version as the argument
-to the 'ysver:version' statement.</t>
+    to the 'ys:version' statement.</t>
 <t>Because the rules put forth in <xref target="I-D.ietf-netmod-yang-module-versioning" format="default"/>
  are designed to work
      well with existing versions of YANG and allow for artifact authors to migrate to this scheme, it is not expected
@@ -452,35 +452,35 @@ skipped.</li>
     prefix "exvermod";
 
     import ietf-yang-revisions { prefix "rev"; }
-    import ietf-yang-semver { prefix "ysver"; }
+import ietf-yang-semver { prefix "ys"; }
 
     description
       "to be completed";
 
     revision 2017-08-30 {
       description "Backport 'wibble' leaf";
-      ysver:version 1.2.2_non_compatible;
+      ys:version 1.2.2_non_compatible;
     }
 
     revision 2017-07-30 {
       description "Rename 'baz' to 'bar'";
-      ysver:version 1.2.1_non_compatible;
+      ys:version 1.2.1_non_compatible;
       rev:non-backwards-compatible;
     }
 
     revision 2017-04-20 {
       description "Add new functionality, leaf 'baz'";
-      ysver:version 1.2.0;
+      ys:version 1.2.0;
     }
 
     revision 2017-04-03 {
       description "Add new functionality, leaf 'foo'";
-      ysver:version 1.1.0;
+      ys:version 1.1.0;
     }
 
     revision 2017-02-07 {
       description "First release version.";
-      ysver:version 1.0.0;
+      ys:version 1.0.0;
     }
 
     // Note: YANG Semver rules do not apply to 0.X.Y labels.
@@ -492,7 +492,7 @@ skipped.</li>
 
     // revision 2017-01-30 {
     //   description "NBC changes to initial revision";
-    //   ysver:version 0.2.0;
+    //   ys:version 0.2.0;
     //   rev:non-backwards-compatible; // optional
     //                         // (theoretically no 
     //                         // 'previous released version')
@@ -500,7 +500,7 @@ skipped.</li>
 
     // revision 2017-01-26 {
     //   description "Initial module version";
-    //   ysver:version 0.1.0;
+    //   ys:version 0.1.0;
     // }
 
     //YANG module definition starts here
@@ -561,7 +561,7 @@ recommended-min-version statements, they are treated as a logical OR.  Removing 
 statements is considered a backwards compatible change.  An example use is:</t>
 <artwork name="" type="" align="left" alt=""><![CDATA[
         import example-module {
-          ysver:recommended-min-version 3.0.0;
+            ys:recommended-min-version 3.0.0;
         }
 ]]></artwork>
 </section>
@@ -702,7 +702,7 @@ have been the initial, pre-NMDA release, and 1.1.0 would have been the NMDA revi
 module ietf-yang-semver {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-semver";
-  prefix ysver;
+prefix ys;
 
   organization
     "IETF NETMOD (Network Modeling) Working Group";
@@ -749,10 +749,10 @@ module ietf-yang-semver {
   // and remove this note.
   // RFC Ed.: replace XXXX with actual RFC number and remove this
   // note.
-  // RFC Ed. update the ysver:version to "1.0.0".
+  // RFC Ed. update the ys:version to "1.0.0".
 
   revision 2024-01-22 {
-    ysver:version "1.0.0-draft-ietf-netmod-yang-semver-13";
+    ys:version "1.0.0-draft-ietf-netmod-yang-semver-13";
     description
       "Initial revision";
     reference
@@ -917,7 +917,7 @@ The extensions defined are only used to document YANG artifacts.</t>
 <ul empty="true" spacing="normal">
 <li>Name: ietf-yang-semver</li>
 <li>XML Namespace: urn:ietf:params:xml:ns:yang:ietf-yang-semver</li>
-<li>Prefix: ysver</li>
+<li>Prefix: ys</li>
 <li>Reference: [RFCXXXX]</li>
 </ul>
 </section>
@@ -1012,7 +1012,7 @@ The extensions defined are only used to document YANG artifacts.</t>
 <name>Example IETF Module Development</name>
 <t>Assume a new YANG module is being developed in the netmod working group in the IETF.
     Initially, this module is being developed in an individual internet draft, draft-jdoe-netmod-example-module.
-    The following represents the initial version tree (i.e., value of ysver:version) of the module as it's being initially developed.</t>
+    The following represents the initial version tree (i.e., value of ys:version) of the module as it's being initially developed.</t>
 <t keepWithNext="true">Version lineage for initial module development:</t>
 <artwork name="" type="" align="left" alt=""><![CDATA[
       0.0.1-draft-jdoe-netmod-example-module-00

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -736,6 +736,12 @@ module ietf-yang-semver {
      Relating to IETF Documents
      (http://trustee.ietf.org/license-info).
 
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.
+
      This version of this YANG module is part of RFC XXXX; see
      the RFC itself for full legal notices.";
 
@@ -795,25 +801,25 @@ module ietf-yang-semver {
        'version' typedef defined in this module.
 
        The statement MUST only be a substatement of the import
-       statement.  Zero, one or more 'recommended-min-version' 
-       statements per parent statement are allowed.  No 
-       substatements for this extension have been 
+       statement.  Zero, one or more 'recommended-min-version'
+       statements per parent statement are allowed.  No
+       substatements for this extension have been
        standardized.
 
        If specified multiple times, then any module revision that
-       satisfies at least one of the 'recommended-min-version' 
-       statements is an acceptable recommended version for 
+       satisfies at least one of the 'recommended-min-version'
+       statements is an acceptable recommended version for
        import.
 
        A particular version of an imported module adheres to an
        import's 'recommended-min-version' extension statement if one
        of the following conditions are met:
 
-       * Has the same MAJOR and MINOR version numbers and same or 
+       * Has the same MAJOR and MINOR version numbers and same or
          greater PATCH number.
-       * Has the same MAJOR version number and greater MINOR number.  
+       * Has the same MAJOR version number and greater MINOR number.
          In this case the PATCH number is ignored.
-       * Has a greater MAJOR version number.  In this case 
+       * Has a greater MAJOR version number.  In this case
          MINOR and PATCH numbers are ignored.
 
        Adding, removing or updating a 'recommended-min-version'

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -80,8 +80,7 @@ document defines a YANG extension for controlling module imports based on these 
 module or submodule is derived.</t>
 <t>This document defines a YANG extension that tags a YANG artifact (i.e., YANG modules, YANG submodules, and YANG packages <xref target="I-D.ietf-netmod-yang-packages" format="default"/>
 )
-        with a version identifier that adheres to extended semantic versioning rules <xref target="SemVer" format="default"/>
-.
+        with a version identifier that adheres to extended semantic versioning rules <xref target="SemVer" format="default"/>.
       The goal being to add a human readable revision label that
     provides compatibility information for the YANG artifact without needing to compare or parse its body.
 The version identifier and rules defined herein represent the RECOMMENDED approach to apply versioning to IETF YANG artifacts.</t>
@@ -102,12 +101,9 @@ The version identifier and rules defined herein represent the RECOMMENDED approa
       <xref target="I-D.ietf-netmod-yang-packages" format="default"/>
  are examples of YANG artifacts
         for the purposes of this document.</li>
-    <li>SemVer: A version string that corresponds to the rules defined in <xref target="SemVer" format="default"/>
-.  This specific camel-case notation is the one used
+    <li>SemVer: A version string that corresponds to the rules defined in <xref target="SemVer" format="default"/>.  This specific camel-case notation is the one used
     by the SemVer 2.0.0 website and used within this document to distinguish between YANG Semver.</li>
-<li>YANG Semver: A version identifier that is consistent with the extended set of semantic versioning rules, based on <xref target="SemVer" format="default"/>
-
-,
+<li>YANG Semver: A version identifier that is consistent with the extended set of semantic versioning rules, based on <xref target="SemVer" format="default"/>,
       defined within this document.</li>
   </ul>
 </section>
@@ -126,6 +122,12 @@ rules (though the inverse is not necessarily true).  YANG Semver is a superset o
     (i.e., you do not use the compatibility modifiers described below), the YANG Semver
     version label will appear as a SemVer version number.</t>
   </section>
+  <section anchor="version_extension" numbered="true" toc="default">
+<name>YANG Semantic Version Extension</name>
+<t>The ietf-yang-semver module defines a "version" extension -- a substatement to a module or submodule's "import" statement -- 
+that takes a YANG semantic version as its argument and specified the version for the given module or submodule.  The syntax for
+the YANG semantic version is defined in a typedef in the same module and described below.</t>
+</section>
   <section anchor="version_pattern" numbered="true" toc="default">
     <name>YANG Semver Pattern</name>
 <t>YANG artifacts that employ semantic versioning as defined in this document MUST use a version identifier that corresponds to the following pattern: 'X.Y.Z_COMPAT'.  Where:
@@ -141,8 +143,7 @@ rules (though the inverse is not necessarily true).  YANG Semver is a superset o
       Pre-release metadata MAY be appended to a YANG Semver string after a trailing '-' character.  Build metadata
       MAY be appended after a trailing '+' character.  If both pre-release and build metadata are present, then build metadata MUST
       follow pre-release metadata.  While build metadata MUST be ignored when comparing YANG semantic versions, pre-release metadata MUST be used
-      during module and submodule development as specified in <xref target="guidelines" format="default"/>
-.  Both pre-release and build metadata are allowed in order
+      during module and submodule development as specified in <xref target="guidelines" format="default"/>.  Both pre-release and build metadata are allowed in order
       to support all the <xref target="SemVer" format="default"/>
  rules.  Thus, a version lineage that follows strict <xref target="SemVer" format="default"/>
  rules
@@ -168,8 +169,7 @@ artifacts. The versioning identifier has the following properties:
       to artifact versions that are not the latest.  However, it does not
       provide for the unlimited branching and updating of older revisions
       which are documented by the general rules in
-<xref target="I-D.ietf-netmod-yang-module-versioning" format="default"/>
-.</li>
+<xref target="I-D.ietf-netmod-yang-module-versioning" format="default"/>.</li>
 <li>YANG artifacts that use the <xref target="SemVer" format="default"/>
 
  versioning
@@ -232,18 +232,18 @@ that all revisions of a given YANG artifact will have a semantic version identif
 </li>
 </ul>
 <t>The '_COMPAT' modifier string is "sticky". Once a revision of a module 
-has a modifier in the revision label, then all descendants of that 
-revision with the same X.Y version digits will also have a modifier. The modifier can change from 
-"_compatible" to "_non_compatible" in a descendant revision, but the 
+has a modifier in the revision label, then all subsequent modules in that branch 
+(i.e., those with the same X.Y version digits) will also have a modifier. The modifier can change from 
+"_compatible" to "_non_compatible" in a subsequent version, but the 
 modifier MUST NOT change from "_non_compatible" to "_compatible" 
 and MUST NOT be removed. The persistence of the "_non_compatible" modifier 
-ensures that comparisons of revision labels do not give the false 
+ensures that comparisons of versions do not give the false 
 impression of compatibility between two potentially non-compatible 
-revisions. If "_non_compatible" was removed, for example between revisions 
+versions. If "_non_compatible" was removed, for example between versions 
 "3.3.2_non_compatible" and "3.3.3" (where "3.3.3" was simply an editorial 
-change), then comparing revision labels of "3.3.3" back to an ancestor 
+change), then comparing versions "3.3.3" to
 "3.0.0" would look like they are backwards compatible when they are 
-not (since "3.3.2_non_compatible" was in the chain of ancestors and 
+not (since "3.3.2_non_compatible" was on the same MAJOR.MINOR branch and 
 introduced a non-backwards-compatible change).</t>
 <t>The YANG artifact name and YANG semantic version uniquely
     identify a revision of said artifact.
@@ -256,22 +256,21 @@ introduced a non-backwards-compatible change).</t>
     if artifact version "1.2.3" has already been defined.</t>
 <section anchor="branching_limitations" numbered="true" toc="default">
 <name>Branching Limitations with YANG Semver</name>
-<t>YANG artifacts that use the YANG Semver revision-label scheme MUST ensure that two artifacts with the same MAJOR version number
+<t>YANG artifacts that use the YANG Semver version scheme MUST ensure that two artifacts with the same MAJOR version number
   and no _compatible or _non_compatible modifiers are backwards compatible.  Therefore, certain branching schemes cannot be used
-  with YANG Semver.  For example, the following branched parent-child module relationship using the following YANG Semver revision 
-  labels is not supported:</t>
+  with YANG Semver.  For example, the following branching approach using the following YANG Semver identifiers
+  is not supported:</t>
 <artwork name="" type="" align="left" alt=""><![CDATA[
       3.5.0 -- 3.6.0 (add leaf foo)
         |
         |
       3.20.0 (added leaf bar)
   ]]></artwork>
-<t> In this case, given only the revision labels 3.6.0 and 3.20.0 without any parent-child relationship information, 
+<t> In this case, given only the YANG Semver identifiers 3.6.0 and 3.20.0, 
     one would assume that 3.20.0 is backwards compatible with 3.6.0. But in the illegal example above, 3.20.0 is not 
     backwards compatible with 3.6.0 since 3.20.0 does not contain the leaf foo.</t>
-<t>Note that this type of branched parent-child relationship, where two revisions have different backwards compatible 
-    changes based on the same parent, is allowed in <xref target="I-D.ietf-netmod-yang-module-versioning" format="default"/>
-.</t>
+<t>Note that this type of branching, where two versions on the same branch have different backwards compatible 
+    changes is allowed in <xref target="I-D.ietf-netmod-yang-module-versioning" format="default"/>.</t>
 </section>
 <section anchor="semver_for_submodules" numbered="true" toc="default">
 <name>YANG Semver with submodules</name>
@@ -279,7 +278,7 @@ introduced a non-backwards-compatible change).</t>
 <t>The rules for determining the version change of a submodule are the same as those defined in <xref target="version_pattern" format="default"/>
  and <xref target="versioning_scheme" format="default"/>
  as applied to YANG modules, except they only apply to the part of the module schema defined within the submodule's file.</t>
-<t>One interesting case is moving definitions from one submodule to another in a way that does not change the resultant schema of the including module.  In this case:</t>
+<t>One interesting case is moving definitions from one submodule to another in a way that does not change the resulting schema of the including module.  In this case:</t>
 <ol spacing="normal" type="1">
 <li>The including module has editorial changes</li>
 <li>The submodule with the schema definition removed has non-backwards-compatible changes</li>
@@ -310,13 +309,13 @@ introduced a non-backwards-compatible change).</t>
 ]]></artwork>
 <t>The tree diagram above illustrates how the version history might
    evolve for an example module.  The tree diagram only shows
-   the parent/child ancestry relationships between the
-   revisions. It does not describe the chronology of the revisions (i.e.
-   when in time each revision was published relative to the other
-   revisions).
+   the branching relationships between the
+   versions. It does not describe the chronology of the versions (i.e.
+   when in time each version was published relative to the other
+   versions).
 </t>
 <t>The following description lists an example of what the chronological 
-   order of the revisions could look like, from oldest revision to newest:
+   order of the versions could look like, from oldest version to newest:
 </t>
 <ul empty="true" spacing="normal">
 <li>0.1.0 - first pre-release module version</li>
@@ -335,7 +334,7 @@ introduced a non-backwards-compatible change).</t>
 <li>3.1.0 - introduce new leaf "wobble" (BC)</li>
 <li>1.2.2_non_compatible - backport "wibble".  This is a BC change but "non_compatible" modifier is sticky. (BC)</li>
 </ul>
-<t>The partial ancestry relationships based on the semantic versioning numbers are as follows:
+<!--<t>The partial ancestry relationships based on the semantic versioning numbers are as follows:
 </t>
 <ul empty="true" spacing="normal">
 <li>1.0.0 &lt; 1.1.0 &lt; 1.2.0 &lt; 2.0.0 &lt; 3.0.0 &lt; 3.1.0</li>
@@ -349,16 +348,16 @@ introduced a non-backwards-compatible change).</t>
    common ancestor of "1.1.0".</t>
 <t>Looking at the version number alone does not indicate ancestry. The 
    module definition in "2.0.0", for example, does not contain all the 
-   contents of "1.3.0".  Version "2.0.0" is not derived from "1.3.0".</t>
+   contents of "1.3.0".  Version "2.0.0" is not derived from "1.3.0".</t>-->
 </section>
 </section>
 <section anchor="semver_update_rules" numbered="true" toc="default">
 <name>YANG Semantic Version Update Rules</name>
-<t>When a new revision of an artifact is produced, then the following
+<t>When a new version of an artifact is produced, then the following
     rules define how the YANG semantic version for the new artifact
-    revision is calculated, based on the changes between the two artifact
-    revisions, and the YANG semantic version of the base artifact
-revision from which the changes are derived.</t>
+    is calculated, based on the changes between the two artifact
+    versions, and the YANG semantic version of the original artifact
+    from which the changes are derived.</t>
 <t>
 The following four rules specify the RECOMMENDED, and REQUIRED minimum, update to a YANG semantic version:
 </t>
@@ -386,8 +385,8 @@ SHOULD be used instead.</li>
 </li>
 <li>
 <t>If an artifact is being updated in an editorial way, then the next
-      version number depends on the format of the current version
-      number:
+      version identifier depends on the format of the current version
+      identifier:
 </t>
 <ol spacing="normal" type="%i">
 <li>"X.Y.Z" - the artifact version SHOULD be updated to "X.Y.Z+1"</li>
@@ -397,41 +396,47 @@ SHOULD be used instead.</li>
     "X.Y.Z+1_non_compatible".</li>
 </ol>
 </li>
-<li>YANG artifact semantic version numbers beginning with 0, i.e.,
+<li>YANG artifact semantic version identifiers beginning with 0, i.e.,
       "0.X.Y", are regarded as pre-release definitions and need not follow the
       rules above.  Either the MINOR or PATCH version numbers may be
       updated, regardless of whether the changes are
       non-backwards-compatible, backwards-compatible, or editorial.  See <xref target="guidelines" format="default"/>
  for
       more details on using this notation during module and submodule development.</li>
-<li>Additional pre-release rules for modules that have had at least one release are specified in <xref target="guidelines" format="default"/>
-.</li>
+<li>Additional pre-release rules for modules that have had at least one release are specified in <xref target="guidelines" format="default"/>.
+</li>
 </ol>
 <t>Although artifacts SHOULD be updated according to the rules
    above, which specify the recommended (and minimum required) update
-   to the version number, the following rules MAY be applied when
-   choosing a new version number:
+   to the version identifier, the following rules MAY be applied when
+   choosing a new version identifier:
 </t>
 <ol spacing="normal" type="1">
-<li>An artifact author MAY update the version number with a more significant
+<li>An artifact author MAY update the version identifier with a more significant
   update than described by the rules above.  For example, an artifact could be
   given a new MAJOR version number (i.e., X+1.0.0), even though no
   non-backwards-compatible changes have occurred, or an artifact could be given
   a new MINOR version number (i.e., X.Y+1.0) even if the changes were only
   editorial.
 </li>
-<li>An artifact author MAY skip version numbers.  That is, an artifact's
-revision history could be 1.0.0, 1.1.0, and 1.3.0 where 1.2.0 is
-skipped.  Note that skipping versions has an impact when importing
-modules by recommended-min.  See <xref target="import_semver" format="default"/>
- for
-  more details on importing modules with revision-label version gaps.</li>
+<li>An artifact author MAY skip versions.  That is, an artifact's
+version history could be 1.0.0, 1.1.0, and 1.3.0 where 1.2.0 is
+skipped.</li>
 </ol>
-<t>Although YANG Semver always indicates when a non-backwards-compatible, or backwards-compatible change may have occurred to a YANG artifact, it does not guarantee that such a change has occurred, or that consumers of that YANG artifact will be impacted by the change.  Hence, tooling, e.g., <xref target="I-D.ietf-netmod-yang-schema-comparison" format="default"/>
-, also plays an important role for comparing YANG artifacts and calculating the likely impact from changes.</t>
+<t>Although YANG Semver always indicates when a non-backwards-compatible, or 
+  backwards-compatible change may have occurred to a YANG artifact, it does not 
+  guarantee that such a change has occurred, or that consumers of that YANG 
+  artifact will be impacted by the change.  Hence, tooling, e.g., 
+  <xref target="I-D.ietf-netmod-yang-schema-comparison" format="default"/>,
+  also plays an important role for comparing YANG artifacts and calculating the likely impact from changes.</t>
 <t>
 <xref target="I-D.ietf-netmod-yang-module-versioning" format="default"/>
- defines the "rev:non-backwards-compatible" extension statement to indicate where non-backwards-compatible changes have occurred in the module revision history.  If a revision entry in a module's revision history includes the "rev:non-backwards-compatible" statement then that MUST be reflected in any YANG semantic version associated with that revision.  However, the reverse does not necessarily hold, i.e., if the MAJOR version has been incremented it does not necessarily mean that a "rev:non-backwards-compatible" statement would be present.</t>
+ defines the "rev:non-backwards-compatible" extension statement to indicate 
+ where non-backwards-compatible changes have occurred in the module revision history.  
+ If a revision entry in a module's revision history includes the "rev:non-backwards-compatible" 
+ statement then that MUST be reflected in any YANG semantic version associated with that revision.  
+ However, the reverse does not necessarily hold, i.e., if the MAJOR version has been incremented it 
+ does not necessarily mean that a "rev:non-backwards-compatible" statement would be present.</t>
 </section>
 <section anchor="examples" numbered="true" toc="default">
 <name>Examples of the YANG Semver Label</name>
@@ -445,7 +450,6 @@ modules by recommended-min.  See <xref target="import_semver" format="default"/>
     yang-version 1.1;
     namespace "urn:example:versioned:module";
     prefix "exvermod";
-    rev:revision-label-scheme "ysver:yang-semver";
 
     import ietf-yang-revisions { prefix "rev"; }
     import ietf-yang-semver { prefix "ysver"; }
@@ -455,28 +459,28 @@ modules by recommended-min.  See <xref target="import_semver" format="default"/>
 
     revision 2017-08-30 {
       description "Backport 'wibble' leaf";
-      rev:revision-label 1.2.2_non_compatible;
+      ysver:version 1.2.2_non_compatible;
     }
 
     revision 2017-07-30 {
       description "Rename 'baz' to 'bar'";
-      rev:revision-label 1.2.1_non_compatible;
+      ysver:version 1.2.1_non_compatible;
       rev:non-backwards-compatible;
     }
 
     revision 2017-04-20 {
       description "Add new functionality, leaf 'baz'";
-      rev:revision-label 1.2.0;
+      ysver:version 1.2.0;
     }
 
     revision 2017-04-03 {
       description "Add new functionality, leaf 'foo'";
-      rev:revision-label 1.1.0;
+      ysver:version 1.1.0;
     }
 
     revision 2017-02-07 {
       description "First release version.";
-      rev:revision-label 1.0.0;
+      ysver:version 1.0.0;
     }
 
     // Note: YANG Semver rules do not apply to 0.X.Y labels.
@@ -488,7 +492,7 @@ modules by recommended-min.  See <xref target="import_semver" format="default"/>
 
     // revision 2017-01-30 {
     //   description "NBC changes to initial revision";
-    //   rev:revision-label 0.2.0;
+    //   ysver:version 0.2.0;
     //   rev:non-backwards-compatible; // optional
     //                         // (theoretically no 
     //                         // 'previous released version')
@@ -496,7 +500,7 @@ modules by recommended-min.  See <xref target="import_semver" format="default"/>
 
     // revision 2017-01-26 {
     //   description "Initial module version";
-    //   rev:revision-label 0.1.0;
+    //   ysver:version 0.1.0;
     // }
 
     //YANG module definition starts here
@@ -506,8 +510,7 @@ modules by recommended-min.  See <xref target="import_semver" format="default"/>
 <section anchor="example_package" numbered="true" toc="default">
 <name>Example of Package Using YANG Semver</name>
 <t>Below is an example YANG package that uses the YANG Semver revision label based on
-      the rules defined in this document.  Note: '\' line wrapping per <xref target="RFC8792"/>
-.
+      the rules defined in this document.  Note: '\' line wrapping per <xref target="RFC8792"/>.
 </t>
 <figure anchor="example-yang-pkg" align="left" suppress-title="false">
 <sourcecode name="example-yang-pkg@2022-12-06T17_00_38Z.json" type="" markers="false">
@@ -539,44 +542,66 @@ modules by recommended-min.  See <xref target="import_semver" format="default"/>
 </section>
 </section>
 <section anchor="import_semver" numbered="true" toc="default">
-<name>Import Module by Semantic Version</name>
+<name>Import Module by YANG Semantic Version</name>
 <t>
 <xref target="I-D.ietf-netmod-yang-module-versioning" format="default"/>
  allows for imports to be
-    done based on a module or a derived revision of a module.  The rev:recommended-min
-    statement can specify either a revision date or a revision label.  The YANG Semver revision-label value can be used as the argument to rev:recommended-min
-    .  When used as such, any module that contains exactly the same YANG semantic version in its revision history may be used
-    to satisfy the import requirement.  For example:</t>
+    done based on the earliest supported date and later using the rev:recommended-min-date extension.  This section
+    defines a similar extension for controlling import by YANG semantic version, as well as the rules for how
+    imports are resolved.</t>
+<section anchor="recommend_min_version" numbered="true" toc="default">
+<name>The recommended-min-version Extension</name>
+<t>The ietf-yang-semver module defines a "recommended-min-version" extension -- a substatement to the "import" statement -- 
+that takes a YANG semantic version as its argument and specifies
+that the minimum version of the associated module being imported SHOULD be greater than or equal to the specified
+value.  The specific conditions for determining if a module's version is greater than or equal is defined in
+<xref target="semver_import_rules" format="default"/> below.  Multiple recommended-min-version statements 
+MAY be specified.  If there are multiple
+recommended-min-version statements, they are treated as a logical OR.  Removing recommended-min-version
+statements is considered a backwards compatible change.  An example use is:</t>
 <artwork name="" type="" align="left" alt=""><![CDATA[
         import example-module {
-          rev:recommended-min 3.0.0;
+          ysver:recommended-min-version 3.0.0;
         }
 ]]></artwork>
-<t>Note: the import lookup does not stop
-    when a non-backward-compatible change is encountered.  That is, if module B imports a module A at or derived from version 2.0.0,
-    resolving that import will pass through a revision of module A with version "2.1.0_non_compatible" in order to determine if the present instance of
-    module A derives from "2.0.0".</t>
-<t>If an import by recommended-min cannot locate the specified revision-label in a given module's revision history, that import will fail.  This is
-  noted in the case of version gaps.  That is, if a module's history includes "1.0.0", "1.1.0", and "1.3.0", an import from recommended-min at "1.2.0" will be
-  unable to locate the specified revision entry and thus the import cannot be satisfied.</t>
+</section>
+<section anchor="semver_import_rules" numbered="true" toc="default">
+<name>Import by YANG Semantic Version Rules</name>
+<t>A module to be imported is considered viable with recommended-min-version if it meets one of the following conditions:</t>
+<ol type="1" spacing="normal">
+<li>Has the same MAJOR and MINOR version numbers and same or greater PATCH number.</li>
+<li>Has the same MAJOR version number and greater MINOR number.  In this case the PATCH number is ignored.</li>
+<li>Has a greater MAJOR version number.  In this case MINOR and PATCH numbers are ignored.</li>
+</ol>
+<t>In all cases, the "_compatible" and "_non_compatible" version modifiers are ignored.</t>
+<t>If the recommended-min-version is specified as 3.1.0, the following examples would be viable:</t>
+<ul empty="true" spacing="normal">
+<li>3.1.1 (by condition 1 above)</li>
+<li>3.2.0 (by condition 2 above)</li>
+<li>4.1.2 (by condition 3 above)</li>
+<li>3.1.1_compatible (by condition 1 above, noting that modifiers are ignored)</li>
+<li>3.1.2_non_compatible (by condition 1 above, noting that modifiers are ignored)</li>
+</ul>
+<t>If an import by recommended-min-version cannot locate a module with a version that is viable according to the conditions above, 
+  the YANG compiler SHOULD emit a warning, and then continue to resolve the import based on established <xref target="RFC7950" format="default"/> rules.</t>
+</section>
 </section>
 <section anchor="guidelines" numbered="true" toc="default">
 <name>Guidelines for Using Semver During Module Development</name>
 <t>This section and the IETF-specific sub-section below provides YANG Semver-specific
     guidelines to consider when developing new YANG modules.  As such this section
-    updates <xref target="RFC8407" format="default"/>
-.</t>
-<t>Development of a brand new YANG module or submodule outside of the IETF that uses YANG Semver as its
-    revision-label scheme SHOULD begin with a 0 for the MAJOR
+    updates <xref target="RFC8407" format="default"/>.</t>
+<t>Development of a brand new YANG module or submodule outside of the IETF that uses the YANG Semver 
+    versioning scheme SHOULD begin with a 0 for the MAJOR
     version component.  This allows the module or submodule to disregard strict
     SemVer rules with respect to non-backwards-compatible changes
     during its initial development.  However, module or submodule developers MAY choose
     to use the SemVer pre-release syntax instead with a 1 for the MAJOR
-    version component.  For example, an initial module or submodule revision-label might
+    version number.  For example, an initial module or submodule version might
     be either 0.0.1 or 1.0.0-alpha.1.  If the authors choose to use the 0 MAJOR version
-    component scheme, they MAY switch to the pre-release scheme with a
-    MAJOR version component of 1 when the module or submodule is nearing initial release
-    (e.g., a module's or submodule's revision label may transition from 0.3.0 to
+    number scheme, they MAY switch to the pre-release scheme with a
+    MAJOR version number of 1 when the module or submodule is nearing initial release
+    (e.g., a module's or submodule's version may transition from 0.3.0 to
     1.0.0-beta.1 to indicate it is more mature and ready for testing).</t>
 <t>When using pre-release notation, the format MUST include at least one alphabetic
     component and MUST end with a '.' or '-' and then one or more digits.  These alphanumeric components will
@@ -590,14 +615,14 @@ modules by recommended-min.  See <xref target="import_semver" format="default"/>
 <li>3.0.0-202007.rc.1</li>
 </ul>
 <t>When developing a new revision of an existing module or submodule using the YANG
-    Semver revision-label scheme, the intended target semantic version MUST
+    Semver versioning scheme, the intended target semantic version MUST
     be used along with pre-release notation.  For example, if a released
-    module or submodule which has a current revision-label of 1.0.0 is being modified
+    module or submodule which has a current version of 1.0.0 is being modified
     with the intent to make non-backwards-compatible changes, the first
     development MAJOR version component must be 2 with some pre-release
     notation such as -alpha.1, making the version 2.0.0-alpha.1.  That said,
     every publicly available release of a module or submodule MUST have a unique YANG
-    Semver revision-label (where a publicly available release is one that
+    Semver identifier (where a publicly available release is one that
     could be implemented by a vendor or consumed by an end user).
     Therefore, it may be prudent to include the
     year or year and month development began (e.g., 2.0.0-201907-alpha.1).
@@ -610,19 +635,19 @@ modules by recommended-min.  See <xref target="import_semver" format="default"/>
     pre-release notation is present in both versions (e.g., 2.0.0-alpha.3
     becomes 1.1.0-alpha.4).  However, on the next development cycle (after 1.1.0 is released), if
     again the new target release is 2.0.0, new pre-release components
-    must be used such that every revision-label for a given module or submodule MUST
+    must be used such that every version for a given module or submodule MUST
     be unique throughout its entire lifecycle (e.g., the first pre-release
     version might be 2.0.0-202005-alpha.1 if keeping the same year and month
     notation mentioned above).</t>
 <section anchor="pre_release_precedence" numbered="true" toc="default">
 <name>Pre-release Version Precedence</name>
 <t>As a module or submodule is developed, the scope of the work may change.  That is, 
-while a ratified module or submodule with revision-label 1.0.0 is initially intended to 
-become 2.0.0 in its next ratified version, the scope of work may change such that the 
+while a released module or submodule with version 1.0.0 is initially intended to 
+become 2.0.0 in its next released version, the scope of work may change such that the 
 final version is 1.1.0.  During the development
 cycle, the pre-release versions could move from
 2.0.0-some-pre-release-tag to 1.1.0-some-pre-release-tag.  This
-downwards changing of version numbers makes it difficult to evaluate
+downwards changing of version identifiers makes it difficult to evaluate
 semantic version rules between pre-release versions.  However, taken
 independently, each pre-release version can be compared to the
 previously ratified version (e.g., 1.1.0-some-pre-release-tag and
@@ -634,18 +659,18 @@ overall changes to the module or submodule.</t>
 </section>
 <section anchor="ietf_guidelines" numbered="true" toc="default">
 <name>YANG Semver in IETF Modules</name>
-<t>All published IETF modules and submodules MUST use YANG semantic versions for their revision-labels.</t>
+<t>All published IETF modules and submodules MUST use YANG semantic versions in their revisions.</t>
 <t>Development of a new module or submodule within the IETF SHOULD begin with the 0 MAJOR number scheme as described above.
-    When revising an existing IETF module or submodule, the revision-label MUST use the target (i.e., intended) MAJOR
-    and MINOR version components with a 0 PATCH version component.  If the intended ratified release will be non-backward-compatible
-    with the current ratified release, the MINOR version component MUST be 0.</t>
+    When revising an existing IETF module or submodule, the version MUST use the target (i.e., intended) MAJOR
+    and MINOR version components with a 0 PATCH version number.  If the intended RFC release will be non-backwards-compatible
+    with the current RFC release, the MINOR version number MUST be 0.</t>
 <section anchor="ietf_module_development" numbered="true" toc="default">
 <name>Guidelines for IETF Module Development</name>
-<t>All IETF modules and submodules in development MUST use the whole document name as a pre-release version string,
+<t>All IETF modules and submodules in development MUST use the whole document name as a pre-release version identifier,
         including the current document revision.  For
         example, if a module or submodule which is currently released at version 1.0.0 is being
         revised to include non-backwards-compatible changes in draft-user-netmod-foo, its
-        development revision-labels MUST include 2.0.0-draft-user-netmod-foo followed by the
+        development versions MUST include 2.0.0-draft-user-netmod-foo followed by the
       document's revision (e.g., 2.0.0-draft-user-netmod-foo-02).  This will ensure each
       pre-release version is unique across the lifecycle of the module or submodule.  Even when using the 0 MAJOR
       version for initial module or submodule development (where MINOR and PATCH can change), appending the
@@ -659,10 +684,10 @@ overall changes to the module or submodule.</t>
 </section>
 <section anchor="ietf_released_modules" numbered="true" toc="default">
 <name>Guidelines for Published IETF Modules</name>
-<t>For IETF YANG modules and submodules that have already been published, revision-labels MUST be
+<t>For IETF YANG modules and submodules that have already been published, versions MUST be
 retroactively applied to all existing revisions when the next new revision is created, starting at
-version "1.0.0" for the initial published revision, and then incrementing according to the YANG Semver version rules specified in <xref target="semver_update_rules" format="default"/>
-.
+version "1.0.0" for the initial published revision, and then incrementing according to the YANG Semver 
+version rules specified in <xref target="semver_update_rules" format="default"/>.
 For example, if a module or submodule started out in the pre-NMDA (<xref target="RFC8342" format="default"/>
 ) world, and then had NMDA support added without
 removing any legacy "state" branches -- and you are looking to add additional new features -- a sensible choice for the target YANG Semver would be 1.2.0 (since 1.0.0 would
@@ -673,16 +698,11 @@ have been the initial, pre-NMDA release, and 1.1.0 would have been the NMDA revi
 <section anchor="yang_module" numbered="true" toc="default">
 <name>YANG Module</name>
 <t>This YANG module contains the typedef for the YANG semantic version and the identity to signal its use.</t>
-<sourcecode name="ietf-yang-semver@2023-01-17.yang" type="" markers="true"><![CDATA[
+<sourcecode name="ietf-yang-semver@2024-01-22.yang" type="" markers="true"><![CDATA[
 module ietf-yang-semver {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-semver";
   prefix ysver;
-  rev:revision-label-scheme "yang-semver";
-
-  import ietf-yang-revisions {
-    prefix rev;
-  }
 
   organization
     "IETF NETMOD (Network Modeling) Working Group";
@@ -706,7 +726,7 @@ module ietf-yang-semver {
     "This module provides type and grouping definitions for YANG
      packages.
 
-     Copyright (c) 2022 IETF Trust and the persons identified as
+     Copyright (c) 2024 IETF Trust and the persons identified as
      authors of the code.  All rights reserved.
 
      Redistribution and use in source and binary forms, with or
@@ -725,8 +745,8 @@ module ietf-yang-semver {
   // note.
   // RFC Ed. update the rev:revision-label to "1.0.0".
 
-  revision 2023-01-17 {
-    rev:label "1.0.0-draft-ietf-netmod-yang-semver-10";
+  revision 2024-01-22 {
+    ysver:version "1.0.0-draft-ietf-netmod-yang-semver-13";
     description
       "Initial revision";
     reference
@@ -734,18 +754,73 @@ module ietf-yang-semver {
   }
 
   /*
-   * Identities
+   * Extensions
    */
 
-  identity yang-semver {
-    base rev:revision-label-scheme-base;
+  extension version {
+    argument yang-semantic-version;
     description
-      "The revision-label scheme corresponds to the YANG Semver
-       scheme which is defined by the pattern in the 'version'
-       typedef below. The rules governing this revision-label
-       scheme are defined in the reference for this identity.";
+      "The version can be used to provide an additional
+       identifier associated with a module or submodule
+       revision.
+
+       The format of the revision label argument MUST conform to the
+       'version' typedef defined in this module.
+
+       The statement MUST only be a substatement of the revision
+       statement.  Zero or one revision label statements per parent
+       statement are allowed.  No substatements for this extension
+       have been standardized.
+
+       Versions MUST be unique amongst all revisions of a
+       module or submodule.
+
+       Adding a version is a backwards-compatible
+       change.  Changing or removing an existing version in
+       the revision history is a non-backwards-compatible
+       change, because it could impact any references to that
+       version.";
     reference
-      "RFC XXXX: YANG Semantic Versioning.";
+      "XXXX: YANG Semantic Versioning;
+       Section 3.2, YANG Semantic Version Extension";
+  }
+
+  extension recommended-min-version {
+    argument yang-semantic-version;
+    description
+      "Recommends the versions of the module that may be imported to
+       one that is greater than or equal to the specified version.
+
+       The argument value MUST conform to the
+       'version' typedef defined in this module.
+
+       The statement MUST only be a substatement of the import
+       statement.  Zero, one or more 'recommended-min-version' 
+       statements per parent statement are allowed.  No 
+       substatements for this extension have been 
+       standardized.
+
+       If specified multiple times, then any module revision that
+       satisfies at least one of the 'recommended-min-version' 
+       statements is an acceptable recommended version for 
+       import.
+
+       A particular version of an imported module adheres to an
+       import's 'recommended-min-version' extension statement if one
+       of the following conditions are met:
+
+       * Has the same MAJOR and MINOR version numbers and same or 
+         greater PATCH number.
+       * Has the same MAJOR version number and greater MINOR number.  
+         In this case the PATCH number is ignored.
+       * Has a greater MAJOR version number.  In this case 
+         MINOR and PATCH numbers are ignored.
+
+       Adding, removing or updating a 'recommended-min-version'
+       statement to an import is a backwards-compatible change.";
+    reference
+      "XXXX: YANG Semantic Versioning; Section 4,
+       Import Module by Semantic Version";
   }
 
   /*
@@ -753,7 +828,7 @@ module ietf-yang-semver {
    */
 
   typedef version {
-    type rev:revision-label {
+    type string {
       pattern '[0-9]+[.][0-9]+[.][0-9]+(_(non_)?compatible)?'
             + '(-[A-Za-z0-9.-]+[.-][0-9]+)?([+][A-Za-z0-9.-]+)?';
     }
@@ -789,11 +864,11 @@ module ietf-yang-semver {
   members whom have worked on the YANG versioning project: Balazs Lengyel, Benoit Claise, Bo Wu, Ebben Aries, Jan Lindblad, Jason Sterne, Joe Clarke,
   Juergen Schoenwaelder, Mahesh Jethanandani, Michael (Wangzitao), Per Andersson, Qin Wu, Reshad Rahman, Tom Hill, and Rob Wilton.</t>
 <t>The initial revision of this document was refactored and built
-   upon <xref target="I-D.clacla-netmod-yang-model-update" format="default"/>
-.  We would like the thank Kevin D'Souza for his initial work in this problem space.</t>
+   upon <xref target="I-D.clacla-netmod-yang-model-update" format="default"/>. 
+   We would like the thank Kevin D'Souza for his initial work in this problem space.</t>
 <t>Discussions on the use of SemVer for YANG versioning has been held
-   with authors of the OpenConfig YANG models based on their own <xref target="openconfigsemver" format="default"/>
-.  We would like thank both
+   with authors of the OpenConfig YANG models based on their own <xref target="openconfigsemver" format="default"/>. 
+   We would like thank both
    Anees Shaikh and Rob Shakir for their input into this problem
    space.</t>
 <t>We would also like to thank Joseph Donahue from the SemVer.org project for his input on SemVer use and overall
@@ -804,30 +879,25 @@ document readability.</t>
 <t>The YANG module specified in this document defines a schema for data
 that is designed to be accessed via network management protocols such
 as NETCONF <xref target="RFC6241"/>
- or RESTCONF <xref target="RFC8040"/>
-.  The lowest NETCONF layer
+ or RESTCONF <xref target="RFC8040"/>.  The lowest NETCONF layer
 is the secure transport layer, and the mandatory-to-implement secure
-transport is Secure Shell (SSH) <xref target="RFC6242"/>
-.  The lowest RESTCONF layer
+transport is Secure Shell (SSH) <xref target="RFC6242"/>.  The lowest RESTCONF layer
 is HTTPS, and the mandatory-to-implement secure transport is TLS
-<xref target="RFC8446"/>
-.</t>
+<xref target="RFC8446"/>.</t>
 <t>The NETCONF access control model <xref target="RFC8341"/>
  provides the means to
 restrict access for particular NETCONF or RESTCONF users to a
 preconfigured subset of all available NETCONF or RESTCONF protocol
 operations and content.</t>
-<t>That said, the YANG module in this document does not define any schema nodes
-(i.e., nothing that can be read or written).  It only defines a typedef and an identity.
-    Therefore, there is no need to further protect any nodes with access control.</t>
+<t>That said, the YANG module in this document does not define any writeable nodes.
+The extensions defined are only used to document YANG artifacts.</t>
 </section>
 <section anchor="iana" numbered="true" toc="default">
 <name>IANA Considerations</name>
 <section anchor="yang-module-registrations" numbered="true" toc="default">
 <name>YANG Module Registrations</name>
 <t>This document requests IANA to register a URI in the "IETF XML Registry"
-<xref target="RFC3688"/>
-.  Following the format in RFC 3688, the following registration
+<xref target="RFC3688"/>.  Following the format in RFC 3688, the following registration
     is requested.</t>
 <ul empty="true" spacing="normal">
 <li>URI: urn:ietf:params:xml:ns:yang:ietf-yang-semver</li>
@@ -835,8 +905,7 @@ operations and content.</t>
 <li>XML: N/A, the requested URI is an XML namespace.</li>
 </ul>
 <t>The following YANG module is requested to be registered in the "IANA
-  Module Names" <xref target="RFC6020"/>
-.  Following the format in RFC 6020,
+  Module Names" <xref target="RFC6020"/>.  Following the format in RFC 6020,
   the following registrations are requested:</t>
 <t>The ietf-yang-semver module:</t>
 <ul empty="true" spacing="normal">
@@ -853,24 +922,19 @@ operations and content.</t>
 <t>IANA is responsible for maintaining and versioning some YANG
     modules and submodules, e.g., iana-if-types.yang <xref target="IfTypeYang" format="default"/>
  and
-    iana-routing-types.yang <xref target="RoutingTypesYang" format="default"/>
-.</t>
+    iana-routing-types.yang <xref target="RoutingTypesYang" format="default"/>.</t>
 <t>In addition to following the rules specified in the IANA
-    Considerations section of <xref target="I-D.ietf-netmod-yang-module-versioning" format="default"/>
-, IANA maintained
+    Considerations section of <xref target="I-D.ietf-netmod-yang-module-versioning" format="default"/>, IANA maintained
     YANG modules and submodules MUST also include a YANG Semver revision label for all
-    new revisions, as defined in <xref target="semantic_versioning" format="default"/>
-.</t>
+    new revisions, as defined in <xref target="semantic_versioning" format="default"/>.</t>
 <t>The YANG Semver version associated with the new revision MUST
-    follow the rules defined in <xref target="semver_update_rules" format="default"/>
-.</t>
+    follow the rules defined in <xref target="semver_update_rules" format="default"/>.</t>
 <t>Note: For IANA maintained YANG modules and submodules that have already been
-    published, revision labels MUST be retroactively applied to all
+    published, versions MUST be retroactively applied to all
     existing revisions when the next new revision is created, starting
     at version "1.0.0" for the initial published revision, and then
     incrementing according to the YANG Semver rules specified in
-<xref target="semver_update_rules" format="default"/>
-.</t>
+<xref target="semver_update_rules" format="default"/>.</t>
 <t>Most changes to IANA maintained YANG modules and submodules are expected to be
     backwards-compatible changes and classified as MINOR version
     changes.  The PATCH version may be incremented instead when only
@@ -893,6 +957,7 @@ operations and content.</t>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6020.xml"/>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml"/>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8407.xml"/>
+<xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7950.xml"/>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-netmod-yang-module-versioning.xml"/>
 </references>
 <references>
@@ -954,7 +1019,7 @@ operations and content.</t>
 ]]></artwork>
 <t>At this point, development stabilizes, and the workgroup adopts the draft.  Thus now the draft becomes
     draft-ietf-netmod-example-module.  The initial pre-release lineage continues as follows.</t>
-<t keepWithNext="true">Continued version lineage after adoption:</t>
+<t keepWithNext="true">Continued version progression after adoption:</t>
 <artwork name="" type="" align="left" alt=""><![CDATA[
     1.0.0-draft-ietf-netmod-example-module-00
       |
@@ -962,7 +1027,7 @@ operations and content.</t>
       |
     1.0.0-draft-ietf-netmod-example-module-02
 ]]></artwork>
-<t>At this point, the draft is ratified and becomes RFC12345 and the YANG module version becomes 1.0.0.</t>
+<t>At this point, the draft is standardized and becomes RFC12345 and the YANG module version becomes 1.0.0.</t>
 <t>A time later, the module needs to be revised to add additional capabilities.  Development will be done in a
     backwards-compatible way.  Two new individual drafts are proposed to go about adding the capabilities in
     different ways: draft-jdoe-netmod-exmod-enhancements and draft-asmith-netmod-exmod-changes.  These are initially
@@ -980,7 +1045,7 @@ operations and content.</t>
       1.1.0-draft-asmith-netmod-exmod-changes-01
 ]]></artwork>
 <t>At this point, the WG decides to merge some aspects of both and adopt the work in asmith's draft
-    as draft-ietf-netmod-exmod-changes.  A single version lineage continues.</t>
+    as draft-ietf-netmod-exmod-changes.  A single version progression continues.</t>
 <artwork name="" type="" align="left" alt=""><![CDATA[
       1.1.0-draft-ietf-netmod-exmod-changes-00
         |
@@ -990,7 +1055,7 @@ operations and content.</t>
         |
       1.1.0-draft-ietf-netmod-exmod-changes-03
 ]]></artwork>
-<t>The draft is ratified, and the new module version becomes 1.1.0.</t>
+<t>The draft is standardized, and the new module version becomes 1.1.0.</t>
 </section>
 </back>
 </rfc>

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -94,7 +94,7 @@ The version identifier and rules defined herein represent the RECOMMENDED approa
   <t keepWithNext="true">Example YANG module with branched revision history.</t>
   <figure>
     <artwork>
-       Module revision date        Version Identifier
+       Module revision date      Example version identifier
          2019-01-01                 &lt;- 1.0.0
              |
          2019-02-01                 &lt;- 2.0.0
@@ -103,9 +103,9 @@ The version identifier and rules defined herein represent the RECOMMENDED approa
              |        \
              |       2019-04-01     &lt;- 2.1.0
              |           |
-             |       2019-05-01     &lt;- 2.2.0
-             |
-         2019-06-01                 &lt;- 3.1.0
+	 2019-05-01      |          &lt;- 3.1.0
+	                 |
+                     2019-06-01     &lt;- 2.2.0
     </artwork>
   </figure>
   <t>The tree diagram above illustrates how an example module's revision history might evolve, over time.</t>

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -88,6 +88,28 @@ The version identifier and rules defined herein represent the RECOMMENDED approa
     the 2.0.0 version of the specification has changed over time without any change to the semantic version itself.  In some cases
     the text has changed in non-backwards-compatible ways.</t>
   </section>
+<section anchor="example_version_tree" title="Examples of How Versioning Is Applied To YANG Module Revisions">
+  <t>The following diagram illustrates how the branched revision history
+    and the YANG Semver version extension statement could be used:</t>
+  <t keepWithNext="true">Example YANG module with branched revision history.</t>
+  <figure>
+    <artwork>
+       Module revision date        Version Identifier
+         2019-01-01                 &lt;- 1.0.0
+             |
+         2019-02-01                 &lt;- 2.0.0
+             |      \
+         2019-03-01  \              &lt;- 3.0.0
+             |        \
+             |       2019-04-01     &lt;- 2.1.0
+             |           |
+             |       2019-05-01     &lt;- 2.2.0
+             |
+         2019-06-01                 &lt;- 3.1.0
+    </artwork>
+  </figure>
+  <t>The tree diagram above illustrates how an example module's revision history might evolve, over time.</t>
+</section>
   <section anchor="terminology" numbered="true" toc="default">
     <name>Terminology and Conventions</name>
     <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT
@@ -452,7 +474,7 @@ skipped.</li>
     prefix "exvermod";
 
     import ietf-yang-revisions { prefix "rev"; }
-import ietf-yang-semver { prefix "ys"; }
+    import ietf-yang-semver { prefix "ys"; }
 
     description
       "to be completed";

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -915,7 +915,7 @@ module ietf-yang-library-semver {
   yang-version 1.1;
   namespace
     "urn:ietf:params:xml:ns:yang:ietf-yang-library-semver";
-  prefix yl-rev;
+  prefix yl-semver;
 
   import ietf-yang-semver {
     prefix ys;
@@ -1111,15 +1111,20 @@ The extensions defined are only used to document YANG artifacts.</t>
 <name>IANA Considerations</name>
 <section anchor="yang-module-registrations" numbered="true" toc="default">
 <name>YANG Module Registrations</name>
-<t>This document requests IANA to register a URI in the "IETF XML Registry"
-<xref target="RFC3688"/>.  Following the format in RFC 3688, the following registration
-    is requested.</t>
+<t>This document requests IANA to register URIs in the "IETF XML Registry"
+<xref target="RFC3688"/>.  Following the format in RFC 3688, the following registrations
+    are requested.</t>
 <ul empty="true" spacing="normal">
 <li>URI: urn:ietf:params:xml:ns:yang:ietf-yang-semver</li>
 <li>Registrant Contact: The IESG.</li>
 <li>XML: N/A, the requested URI is an XML namespace.</li>
 </ul>
-<t>The following YANG module is requested to be registered in the "IANA
+<ul empty="true" spacing="normal">
+<li>URI: urn:ietf:params:xml:ns:yang:ietf-yang-library-semver</li>
+<li>Registrant Contact: The IESG.</li>
+<li>XML: N/A, the requested URI is an XML namespace.</li>
+</ul>
+<t>The following YANG modules are requested to be registered in the "IANA
   Module Names" <xref target="RFC6020"/>.  Following the format in RFC 6020,
   the following registrations are requested:</t>
 <t>The ietf-yang-semver module:</t>
@@ -1127,6 +1132,13 @@ The extensions defined are only used to document YANG artifacts.</t>
 <li>Name: ietf-yang-semver</li>
 <li>XML Namespace: urn:ietf:params:xml:ns:yang:ietf-yang-semver</li>
 <li>Prefix: ys</li>
+<li>Reference: [RFCXXXX]</li>
+</ul>
+<t>The ietf-yang-library-semver module:</t>
+<ul empty="true" spacing="normal">
+<li>Name: ietf-yang-library-semver</li>
+<li>XML Namespace: urn:ietf:params:xml:ns:yang:ietf-yang-library-semver</li>
+<li>Prefix: yl-semver</li>
 <li>Reference: [RFCXXXX]</li>
 </ul>
 </section>

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -593,18 +593,20 @@ statements is considered a backwards compatible change.  An example use is:</t>
 <name>Import by YANG Semantic Version Rules</name>
 <t>A module to be imported is considered viable with recommended-min-version if it meets one of the following conditions:</t>
 <ol type="1" spacing="normal">
-<li>Has the same MAJOR and MINOR version numbers and same or greater PATCH number.</li>
-<li>Has the same MAJOR version number and greater MINOR number.  In this case the PATCH number is ignored.</li>
-<li>Has a greater MAJOR version number.  In this case MINOR and PATCH numbers are ignored.</li>
+<li>Has the exact MAJOR, MINOR, PATCH and "_compatible" and "_non_compatible" modifiers as in the recommend-min-version value.</li>
+<li>Has the same MAJOR and MINOR version numbers a greater PATCH number.  In this case, "_compatible" and "_non_compatible modifiers"
+are ignored.</li>
+<li>Has the same MAJOR version number and greater MINOR number.  In this case the PATCH number and the "_compatible" and "_non_compatible" modifiers are ignored.</li>
+<li>Has a greater MAJOR version number.  In this case MINOR and PATCH numbers and "_compatible" and "_non_compatible" modifiers are ignored.</li>
 </ol>
-<t>In all cases, the "_compatible" and "_non_compatible" version modifiers are ignored.</t>
 <t>If the recommended-min-version is specified as 3.1.0, the following examples would be viable:</t>
 <ul empty="true" spacing="normal">
-<li>3.1.1 (by condition 1 above)</li>
-<li>3.2.0 (by condition 2 above)</li>
-<li>4.1.2 (by condition 3 above)</li>
-<li>3.1.1_compatible (by condition 1 above, noting that modifiers are ignored)</li>
-<li>3.1.2_non_compatible (by condition 1 above, noting that modifiers are ignored)</li>
+<li>3.1.0 (by condition 1 above)</li>
+<li>3.1.1 (by condition 2 above)</li>
+<li>3.2.0 (by condition 3 above)</li>
+<li>4.1.2 (by condition 4 above)</li>
+<li>3.1.1_compatible (by condition 2 above, noting that modifiers are ignored)</li>
+<li>3.1.2_non_compatible (by condition 2 above, noting that modifiers are ignored)</li>
 </ul>
 <t>If an import by recommended-min-version cannot locate a module with a version that is viable according to the conditions above, 
   the YANG compiler SHOULD emit a warning, and then continue to resolve the import based on established <xref target="RFC7950" format="default"/> rules.</t>

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -788,7 +788,7 @@ module ietf-yang-semver {
   extension version {
     argument yang-semantic-version;
     description
-      "The version can be used to provide an additional
+      "The version extension can be used to provide an additional
        identifier associated with a module or submodule
        revision.
 
@@ -819,8 +819,8 @@ module ietf-yang-semver {
       "Recommends the versions of the module that may be imported to
        one that is greater than or equal to the specified version.
 
-       The argument value MUST conform to the
-       'version' typedef defined in this module.
+       The format of the recommended-min-version extension argument
+       MUST conform to the 'version' typedef defined in this module.
 
        The statement MUST only be a substatement of the import
        statement.  Zero, one or more 'recommended-min-version'

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -146,7 +146,7 @@ rules (though the inverse is not necessarily true).  YANG Semver is a superset o
   </section>
   <section anchor="version_extension" numbered="true" toc="default">
 <name>YANG Semantic Version Extension</name>
-<t>The ietf-yang-semver module defines a "version" extension -- a substatement to a module or submodule's "import" statement -- 
+<t>The ietf-yang-semver module defines a "version" extension -- a substatement to a module or submodule's "revision" statement -- 
 that takes a YANG semantic version as its argument and specified the version for the given module or submodule.  The syntax for
 the YANG semantic version is defined in a typedef in the same module and described below.</t>
 </section>

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -813,7 +813,7 @@ module ietf-yang-semver {
   // note.
   // RFC Ed. update the ys:version to "1.0.0".
 
-  revision 2024-01-22 {
+  revision 2024-03-01 {
     ys:version "1.0.0-draft-ietf-netmod-yang-semver-13";
     description
       "Initial revision";

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -2,7 +2,7 @@
 <rfc xmlns:xi="http://www.w3.org/2001/XInclude" updates="8407,8525,7950" category="std" ipr="trust200902" consensus="true" docName="draft-ietf-netmod-yang-semver-13" xml:lang="en" obsoletes="" submissionType="IETF" version="3">
   <front>
     <title abbrev="YANG Semver">YANG Semantic Versioning</title>
-<seriesInfo name="Internet-Draft" value="draft-ietf-netmod-yang-semver-13"/>
+<seriesInfo name="Internet-Draft" value="draft-ietf-netmod-yang-semver-14"/>
 
     <author initials="J." surname="Clarke" fullname="Joe Clarke" role="editor">
       <organization>Cisco Systems, Inc.</organization>
@@ -910,7 +910,7 @@ module ietf-yang-semver {
 }
     ]]></sourcecode>
 <t>This YANG module contains the augmentations to the ietf-yang-library.</t>
-<sourcecode name="ietf-yang-library-semver@2024-03-01.yang" type="" markers="true"><![CDATA[
+<sourcecode name="ietf-yang-library-semver@2024-03-02.yang" type="" markers="true"><![CDATA[
 module ietf-yang-library-semver {
   yang-version 1.1;
   namespace
@@ -978,8 +978,8 @@ module ietf-yang-library-semver {
   // RFC Ed.: please replace ys:version with 1.0.0 and
   // remove this note.
 
-  revision 2024-03-01 {
-    ys:version "1.0.0-draft-ietf-netmod-yang-semver-13";
+  revision 2024-03-02 {
+    ys:version "1.0.0-draft-ietf-netmod-yang-semver-14";
     description
       "Initial revision";
     reference

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -63,7 +63,7 @@
     </author>
     <date/>
     <abstract>
-<t>This document specifies a YANG extension along with guidelines guidelines for applying an extended set of
+<t>This document specifies a YANG extension along with guidelines for applying an extended set of
     semantic versioning rules to revisions of YANG artifacts (e.g., modules and packages).  Additionally, this
 document defines a YANG extension for controlling module imports based on these modified semantic versioning rules.</t>
     </abstract>

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -724,7 +724,7 @@ have been the initial, pre-NMDA release, and 1.1.0 would have been the NMDA revi
 module ietf-yang-semver {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-semver";
-prefix ys;
+  prefix ys;
 
   organization
     "IETF NETMOD (Network Modeling) Working Group";

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -81,7 +81,7 @@ module or submodule is derived.</t>
 <t>This document defines a YANG extension that tags a YANG artifact (i.e., YANG modules, YANG submodules, and YANG packages <xref target="I-D.ietf-netmod-yang-packages" format="default"/>
 )
         with a version identifier that adheres to extended semantic versioning rules <xref target="SemVer" format="default"/>.
-      The goal being to add a human readable revision label that
+      The goal being to add a human readable version identifier that
     provides compatibility information for the YANG artifact without needing to compare or parse its body.
 The version identifier and rules defined herein represent the RECOMMENDED approach to apply versioning to IETF YANG artifacts.</t>
     <t>Note that a specific revision of the SemVer 2.0.0 specification is referenced here (from June 19, 2020) to provide an immutable version.  This is because
@@ -254,7 +254,7 @@ that all revisions of a given YANG artifact will have a semantic version identif
 </li>
 </ul>
 <t>The '_COMPAT' modifier string is "sticky". Once a revision of a module 
-has a modifier in the revision label, then all subsequent modules in that branch 
+has a modifier in the version identifier, then all subsequent modules in that branch 
 (i.e., those with the same X.Y version digits) will also have a modifier. The modifier can change from 
 "_compatible" to "_non_compatible" in a subsequent version, but the 
 modifier MUST NOT change from "_non_compatible" to "_compatible" 
@@ -531,7 +531,7 @@ skipped.</li>
 </section>
 <section anchor="example_package" numbered="true" toc="default">
 <name>Example of Package Using YANG Semver</name>
-<t>Below is an example YANG package that uses the YANG Semver revision label based on
+<t>Below is an example YANG package that uses the YANG Semver version identifier based on
       the rules defined in this document.  Note: '\' line wrapping per <xref target="RFC8792"/>.
 </t>
 <figure anchor="example-yang-pkg" align="left" suppress-title="false">
@@ -792,11 +792,11 @@ module ietf-yang-semver {
        identifier associated with a module or submodule
        revision.
 
-       The format of the revision label argument MUST conform to the
-       'version' typedef defined in this module.
+       The format of the version extension argument MUST conform
+       to the 'version' typedef defined in this module.
 
        The statement MUST only be a substatement of the revision
-       statement.  Zero or one revision label statements per parent
+       statement.  Zero or one version statements per parent
        statement are allowed.  No substatements for this extension
        have been standardized.
 
@@ -862,7 +862,7 @@ module ietf-yang-semver {
     }
     description
       "Represents a YANG semantic version.  The rules governing the
-       use of this revision label scheme are defined in the
+       use of this version identifier are defined in the
        reference for this typedef.";
     reference
       "RFC XXXX: YANG Semantic Versioning.";
@@ -953,7 +953,7 @@ The extensions defined are only used to document YANG artifacts.</t>
     iana-routing-types.yang <xref target="RoutingTypesYang" format="default"/>.</t>
 <t>In addition to following the rules specified in the IANA
     Considerations section of <xref target="I-D.ietf-netmod-yang-module-versioning" format="default"/>, IANA maintained
-    YANG modules and submodules MUST also include a YANG Semver revision label for all
+    YANG modules and submodules MUST also include a YANG Semver version identifier for all
     new revisions, as defined in <xref target="semantic_versioning" format="default"/>.</t>
 <t>The YANG Semver version associated with the new revision MUST
     follow the rules defined in <xref target="semver_update_rules" format="default"/>.</t>

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" updates="8407,8525,7950" category="std" ipr="trust200902" consensus="true" docName="draft-ietf-netmod-yang-semver-14" xml:lang="en" obsoletes="" submissionType="IETF" version="3">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" updates="8407,8525,7950" category="std" ipr="trust200902" consensus="true" docName="draft-ietf-netmod-yang-semver-15" xml:lang="en" obsoletes="" submissionType="IETF" version="3">
   <front>
     <title abbrev="YANG Semver">YANG Semantic Versioning</title>
-<seriesInfo name="Internet-Draft" value="draft-ietf-netmod-yang-semver-14"/>
+<seriesInfo name="Internet-Draft" value="draft-ietf-netmod-yang-semver-15"/>
 
     <author initials="J." surname="Clarke" fullname="Joe Clarke" role="editor">
       <organization>Cisco Systems, Inc.</organization>

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -26,8 +26,8 @@
       </address>
     </author>
     <author initials="R." surname="Rahman" fullname="Reshad Rahman">
-      <organization abbrev="Graphiant">
-        Graphiant
+      <organization abbrev="Equinix">
+        Equinix
       </organization>
       <address>
         <email>reshad@yahoo.com</email>

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -442,7 +442,7 @@ skipped.</li>
 <name>Examples of the YANG Semver Label</name>
 <section anchor="example_module" numbered="true" toc="default">
 <name>Example Module Using YANG Semver</name>
-<t>Below is a sample YANG module that uses the YANG Semver revision-label
+<t>Below is a sample YANG module that uses YANG Semver
         based on the rules defined in this document.
 </t>
 <artwork name="" type="" align="left" alt=""><![CDATA[
@@ -749,7 +749,7 @@ module ietf-yang-semver {
   // and remove this note.
   // RFC Ed.: replace XXXX with actual RFC number and remove this
   // note.
-  // RFC Ed. update the rev:revision-label to "1.0.0".
+  // RFC Ed. update the ysver:version to "1.0.0".
 
   revision 2024-01-22 {
     ysver:version "1.0.0-draft-ietf-netmod-yang-semver-13";
@@ -1012,7 +1012,7 @@ The extensions defined are only used to document YANG artifacts.</t>
 <name>Example IETF Module Development</name>
 <t>Assume a new YANG module is being developed in the netmod working group in the IETF.
     Initially, this module is being developed in an individual internet draft, draft-jdoe-netmod-example-module.
-    The following represents the initial version tree (i.e., value of revision-label) of the module as it's being initially developed.</t>
+    The following represents the initial version tree (i.e., value of ysver:version) of the module as it's being initially developed.</t>
 <t keepWithNext="true">Version lineage for initial module development:</t>
 <artwork name="" type="" align="left" alt=""><![CDATA[
       0.0.1-draft-jdoe-netmod-example-module-00

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" updates="8407" category="std" ipr="trust200902" consensus="true" docName="draft-ietf-netmod-yang-semver-13" xml:lang="en" obsoletes="" submissionType="IETF" version="3">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" updates="8407,8525,7950" category="std" ipr="trust200902" consensus="true" docName="draft-ietf-netmod-yang-semver-13" xml:lang="en" obsoletes="" submissionType="IETF" version="3">
   <front>
     <title abbrev="YANG Semver">YANG Semantic Versioning</title>
 <seriesInfo name="Internet-Draft" value="draft-ietf-netmod-yang-semver-13"/>
@@ -65,7 +65,8 @@
     <abstract>
 <t>This document specifies a YANG extension along with guidelines for applying an extended set of
     semantic versioning rules to revisions of YANG artifacts (e.g., modules and packages).  Additionally, this
-document defines a YANG extension for controlling module imports based on these modified semantic versioning rules.</t>
+document defines a YANG extension for controlling module imports based on these modified semantic versioning rules.
+This document updates RFCs 7950, 8407, and 8525.</t>
     </abstract>
   </front>
   <middle>
@@ -83,7 +84,8 @@ module or submodule is derived.</t>
         with a version identifier that adheres to extended semantic versioning rules <xref target="SemVer" format="default"/>.
       The goal being to add a human readable version identifier that
     provides compatibility information for the YANG artifact without needing to compare or parse its body.
-The version identifier and rules defined herein represent the RECOMMENDED approach to apply versioning to IETF YANG artifacts.</t>
+The version identifier and rules defined herein represent the RECOMMENDED approach to apply versioning to IETF YANG artifacts.
+This document defines augmentations to ietf-yang-library to reflect the version of YANG modules within the module-set data.</t>
     <t>Note that a specific revision of the SemVer 2.0.0 specification is referenced here (from June 19, 2020) to provide an immutable version.  This is because
     the 2.0.0 version of the specification has changed over time without any change to the semantic version itself.  In some cases
     the text has changed in non-backwards-compatible ways.</t>
@@ -717,10 +719,48 @@ have been the initial, pre-NMDA release, and 1.1.0 would have been the NMDA revi
 </section>
 </section>
 </section>
-<section anchor="yang_module" numbered="true" toc="default">
-<name>YANG Module</name>
+<section title="Updates to ietf-yang-library" anchor="ietf_yang_library_updates">
+<t>This document updates YANG 1.1 <xref target="RFC7950"/>
+ and YANG library <xref target="RFC8525"/>
+ to clarify how ambiguous
+    module imports are resolved.  It also defines the YANG module, ietf-yang-library-semver, that augments YANG library <xref target="RFC8525"/>
+ with
+    a version leaf for modules and submodules.</t>
+<section title="YANG library versioning augmentations">
+<t></t>
+<t>The "ietf-yang-library-semver" YANG module has the following
+            structure (using the notation defined in <xref target="RFC8340"/>):</t>
+<figure>
+<artwork name="ietf-yang-library-semver tree" type="" align="left" alt="">
+<![CDATA[
+module: ietf-yang-library-semver
+
+  augment /yanglib:yang-library/yanglib:module-set/yanglib:module:
+    +--ro version?   ys:version
+  augment /yanglib:yang-library/yanglib:module-set/yanglib:module
+            /yanglib:submodule:
+    +--ro version?   ys:version
+  augment /yanglib:yang-library/yanglib:module-set
+            /yanglib:import-only-module:
+    +--ro version?   ys:version
+  augment /yanglib:yang-library/yanglib:module-set
+            /yanglib:import-only-module/yanglib:submodule:
+    +--ro version?   ys:version
+]]>
+</artwork>
+</figure>
+
+<section title="Advertising version">
+<t>The ietf-yang-library-semver YANG module augments the "module" and "submodule" lists in ietf-yang-library with "version"
+        leafs to optionally declare the version identifier associated with each module and submodule.</t>
+</section>
+</section>
+</section>
+
+<section anchor="yang_modules" numbered="true" toc="default">
+<name>YANG Modules</name>
 <t>This YANG module contains the typedef for the YANG semantic version and the identity to signal its use.</t>
-<sourcecode name="ietf-yang-semver@2024-01-22.yang" type="" markers="true"><![CDATA[
+<sourcecode name="ietf-yang-semver@2024-03-01.yang" type="" markers="true"><![CDATA[
 module ietf-yang-semver {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-semver";
@@ -869,6 +909,153 @@ module ietf-yang-semver {
   }
 }
     ]]></sourcecode>
+<t>This YANG module contains the augmentations to the ietf-yang-library.</t>
+<sourcecode name="ietf-yang-library-semver@2024-03-01.yang" type="" markers="true"><![CDATA[
+module ietf-yang-library-semver {
+  yang-version 1.1;
+  namespace
+    "urn:ietf:params:xml:ns:yang:ietf-yang-library-semver";
+  prefix yl-rev;
+
+  import ietf-yang-semver {
+    prefix ys;
+    reference
+      "XXXX: YANG Semantic Versioning";
+  }
+  import ietf-yang-library {
+    prefix yanglib;
+    reference
+      "RFC 8525: YANG Library";
+  }
+
+  organization
+    "IETF NETMOD (Network Modeling) Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     Author:   Joe Clarke
+               <mailto:jclarke@cisco.com>
+
+     Author:   Reshad Rahman
+               <mailto:reshad@yahoo.com>
+
+     Author:   Robert Wilton
+               <mailto:rwilton@cisco.com>
+
+     Author:   Balazs Lengyel
+               <mailto:balazs.lengyel@ericsson.com>
+
+     Author:   Jason Sterne
+               <mailto:jason.sterne@nokia.com>";
+  description
+    "This module contains augmentations to YANG Library to add module
+     and submodule level version identifiers.
+
+     Copyright (c) 2024 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Revised BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC XXXX; see
+     the RFC itself for full legal notices.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.";
+
+  // RFC Ed.: update the date below with the date of RFC publication
+  // and remove this note.
+  // RFC Ed.: replace XXXX (including in the imports above) with
+  // actual RFC number and remove this note.
+  // RFC Ed.: please replace ys:version with 1.0.0 and
+  // remove this note.
+
+  revision 2024-03-01 {
+    ys:version "1.0.0-draft-ietf-netmod-yang-semver-13";
+    description
+      "Initial revision";
+    reference
+      "XXXX: YANG Semantic Versioning";
+  }
+
+  // library 1.0 modules-state is not augmented with version
+
+  augment "/yanglib:yang-library/yanglib:module-set/yanglib:module" {
+    description
+      "Add a version to module information";
+    leaf version {
+      type ys:version;
+      description
+        "The version associated with this module revision.
+         The value MUST match the version value in the
+         specific revision of the module loaded in this module-set.";
+      reference
+        "XXXX: YANG Semantic Versioning;
+         Section 7.1.1, Advertising version";
+    }
+  }
+
+  augment
+    "/yanglib:yang-library/yanglib:module-set/yanglib:module/"
+  + "yanglib:submodule" {
+    description
+      "Add a version to submodule information";
+    leaf version {
+      type ys:version;
+      description
+        "The version associated with this submodule revision.
+         The value MUST match the version value in the
+         specific revision of the submodule included by the module
+         loaded in this module-set.";
+      reference
+        "XXXX: YANG Semantic Versioning;
+         Section 7.1.1, Advertising version";
+    }
+  }
+
+  augment "/yanglib:yang-library/yanglib:module-set/"
+        + "yanglib:import-only-module" {
+    description
+      "Add a version to module information";
+    leaf version {
+      type ys:version;
+      description
+        "The version associated with this module revision.
+         The value MUST match the version value in the
+         specific revision of the module included in this
+         module-set.";
+      reference
+        "XXXX: YANG Semantic Versioning;
+         Section 7.1.1, Advertising version";
+    }
+  }
+
+  augment "/yanglib:yang-library/yanglib:module-set/"
+        + "yanglib:import-only-module/yanglib:submodule" {
+    description
+      "Add a version to submodule information";
+    leaf version {
+      type ys:version;
+      description
+        "The version associated with this submodule revision.
+         The value MUST match the version value in the specific
+         revision of the submodule included by the import-only-module
+         loaded in this module-set.";
+      reference
+        "XXXX: Updated YANG Module Revision Handling;
+         Section 7.1.1, Advertising version";
+    }
+  }
+}
+]]></sourcecode>
 </section>
 <section anchor="contributors" numbered="true" toc="default">
 <name>Contributors</name>
@@ -986,6 +1173,7 @@ The extensions defined are only used to document YANG artifacts.</t>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml"/>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8407.xml"/>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7950.xml"/>
+<xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8525.xml"/>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-netmod-yang-module-versioning.xml"/>
 </references>
 <references>
@@ -993,6 +1181,7 @@ The extensions defined are only used to document YANG artifacts.</t>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.clacla-netmod-yang-model-update.xml"/>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-netmod-yang-packages.xml"/>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-netmod-yang-schema-comparison.xml"/>
+<xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8340.xml"/>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8342.xml"/>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6241.xml"/>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6242.xml"/>

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" updates="8407" category="std" ipr="trust200902" consensus="true" docName="draft-ietf-netmod-yang-semver-12" xml:lang="en" obsoletes="" submissionType="IETF" version="3">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" updates="8407" category="std" ipr="trust200902" consensus="true" docName="draft-ietf-netmod-yang-semver-13" xml:lang="en" obsoletes="" submissionType="IETF" version="3">
   <front>
     <title abbrev="YANG Semver">YANG Semantic Versioning</title>
-    <seriesInfo name="Internet-Draft" value="draft-ietf-netmod-yang-semver-12"/>
+<seriesInfo name="Internet-Draft" value="draft-ietf-netmod-yang-semver-13"/>
+
     <author initials="J." surname="Clarke" fullname="Joe Clarke" role="editor">
       <organization>Cisco Systems, Inc.</organization>
       <address>
@@ -62,9 +63,9 @@
     </author>
     <date/>
     <abstract>
-      <t>This document specifies a scheme and guidelines for applying an extended set of
+<t>This document specifies a YANG extension along with guidelines guidelines for applying an extended set of
     semantic versioning rules to revisions of YANG artifacts (e.g., modules and packages).  Additionally, this
-    document defines an RFCAAAA-compliant revision-label-scheme for this YANG semantic versioning scheme.</t>
+document defines a YANG extension for controlling module imports based on these modified semantic versioning rules.</t>
     </abstract>
   </front>
   <middle>
@@ -76,15 +77,14 @@
    to modified rules for updating YANG modules and submodules, a means to signal when a new revision of a module or submodule has
    non-backwards-compatible (NBC) changes compared to its previous revision, and a scheme that
    uses the revision history as a lineage for determining from where a specific revision of a YANG
-   module or submodule is derived.  Additionally, section 3.4 of <xref target="I-D.ietf-netmod-yang-module-versioning" format="default"/>
-   defines a revision-label which can be used as an alias to provide additional context or as a meaningful label to refer to a specific revision.</t>
-      <t>This document defines a revision-label scheme that uses extended semantic versioning rules <xref target="SemVer" format="default"/>
- for YANG artifacts
-    (i.e., YANG modules, YANG submodules, and YANG packages <xref target="I-D.ietf-netmod-yang-packages" format="default"/>
-) as well as the
-    revision label definition for using this scheme.  The goal being to add a human readable revision label that
+module or submodule is derived.</t>
+<t>This document defines a YANG extension that tags a YANG artifact (i.e., YANG modules, YANG submodules, and YANG packages <xref target="I-D.ietf-netmod-yang-packages" format="default"/>
+)
+        with a version identifier that adheres to extended semantic versioning rules <xref target="SemVer" format="default"/>
+.
+      The goal being to add a human readable revision label that
     provides compatibility information for the YANG artifact without needing to compare or parse its body.
-    The label and rules defined herein represent the RECOMMENDED revision label scheme for IETF YANG artifacts.</t>
+The version identifier and rules defined herein represent the RECOMMENDED approach to apply versioning to IETF YANG artifacts.</t>
     <t>Note that a specific revision of the SemVer 2.0.0 specification is referenced here (from June 19, 2020) to provide an immutable version.  This is because
     the 2.0.0 version of the specification has changed over time without any change to the semantic version itself.  In some cases
     the text has changed in non-backwards-compatible ways.</t>
@@ -105,7 +105,8 @@
     <li>SemVer: A version string that corresponds to the rules defined in <xref target="SemVer" format="default"/>
 .  This specific camel-case notation is the one used
     by the SemVer 2.0.0 website and used within this document to distinguish between YANG Semver.</li>
-    <li>YANG Semver: A revision-label identifier that is consistent with the extended set of semantic versioning rules, based on <xref target="SemVer" format="default"/>
+<li>YANG Semver: A version identifier that is consistent with the extended set of semantic versioning rules, based on <xref target="SemVer" format="default"/>
+
 ,
       defined within this document.</li>
   </ul>
@@ -121,14 +122,13 @@
     <t>
       <xref target="SemVer" format="default"/>
  is completely compatible with YANG Semver in that a SemVer semantic version number is legal according to the YANG Semver
-    rules (though the inverse is not necessarily true).  YANG Semver is a superset of the SemVer rules, and allow for limited branching within YANG artifacts.  If no branching occurs within a YANG artifact
+rules (though the inverse is not necessarily true).  YANG Semver is a superset of the SemVer rules, and allows for limited branching within YANG artifacts.  If no branching occurs within a YANG artifact
     (i.e., you do not use the compatibility modifiers described below), the YANG Semver
     version label will appear as a SemVer version number.</t>
   </section>
   <section anchor="version_pattern" numbered="true" toc="default">
     <name>YANG Semver Pattern</name>
-    <t>YANG artifacts that employ semantic versioning as defined in this document MUST use a version string (e.g., in revision-label
-      or as a package version) that corresponds to the following pattern: 'X.Y.Z_COMPAT'.  Where:
+<t>YANG artifacts that employ semantic versioning as defined in this document MUST use a version identifier that corresponds to the following pattern: 'X.Y.Z_COMPAT'.  Where:
     </t>
     <ul spacing="normal">
       <li>X, Y and Z are mandatory non-negative integers that are each less than or equal to 2147483647 (i.e., the maximum signed 32-bit integer value) and MUST NOT contain leading zeroes,</li>
@@ -147,17 +147,13 @@
  rules.  Thus, a version lineage that follows strict <xref target="SemVer" format="default"/>
  rules
       is allowed for a YANG artifact.</t>
-<t>To signal the use of this versioning scheme, modules and submodules MUST set the revision-label-scheme extension, as defined in
-<xref target="I-D.ietf-netmod-yang-module-versioning" format="default"/>
-,
- to the identity "yang-semver".  That identity value is defined
-      in the ietf-yang-semver module below.</t>
-<t>Additionally, this ietf-yang-semver module defines a typedef that formally specifies the syntax of the YANG Semver.</t>
+<t>The ietf-yang-semver module included in this document defines an extension to apply a YANG Semver identifier to a YANG artifact as well as 
+  a typedef that formally specifies the syntax of the YANG Semver.</t>
 </section>
 <section anchor="versioning_scheme" numbered="true" toc="default">
 <name>Semantic Versioning Scheme for YANG Artifacts</name>
 <t>This document defines the YANG semantic versioning scheme that is used for YANG
-    artifacts that employ the YANG Semver label. The versioning scheme has the following properties:
+artifacts. The versioning identifier has the following properties:
 </t>
 <ul spacing="normal">
 <li>The YANG semantic versioning scheme is extended from version
@@ -174,23 +170,24 @@
       which are documented by the general rules in
 <xref target="I-D.ietf-netmod-yang-module-versioning" format="default"/>
 .</li>
-<li>YANG artifacts that follow the <xref target="SemVer" format="default"/>
+<li>YANG artifacts that use the <xref target="SemVer" format="default"/>
+
  versioning
       scheme are fully compatible with implementations that understand
       the YANG semantic versioning scheme defined in this document.</li>
 <li>If updates are always restricted to the latest revision
-      of the artifact only, then the version numbers used by the YANG
+of the artifact only, then the version identifiers used by the YANG
       semantic versioning scheme are exactly the same as those defined
       by the <xref target="SemVer" format="default"/>
  versioning scheme.</li>
 </ul>
 <t>Every YANG module and submodule versioned using the YANG semantic versioning
     scheme specifies the module's or submodule's semantic version as the argument
-    to the 'rev:revision-label' statement.</t>
+to the 'ysver:version' statement.</t>
 <t>Because the rules put forth in <xref target="I-D.ietf-netmod-yang-module-versioning" format="default"/>
  are designed to work
      well with existing versions of YANG and allow for artifact authors to migrate to this scheme, it is not expected
-     that all revisions of a given YANG artifact will have a semantic version label.  For example, the first revision of
+that all revisions of a given YANG artifact will have a semantic version identifier.  For example, the first revision of
      a module or submodule may have been produced before this scheme was available.</t>
 <t>YANG packages that make use of this YANG Semver will reflect that in the package metadata.</t>
 <t>

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -591,15 +591,15 @@ statements is considered a backwards compatible change.  An example use is:</t>
 </section>
 <section anchor="semver_import_rules" numbered="true" toc="default">
 <name>Import by YANG Semantic Version Rules</name>
-<t>A module to be imported is considered viable with recommended-min-version if it meets one of the following conditions:</t>
+<t>A module to be imported is considered as meeting the recommended minimum version criteria if it meets one of the following conditions::</t>
 <ol type="1" spacing="normal">
-<li>Has the exact MAJOR, MINOR, PATCH and "_compatible" and "_non_compatible" modifiers as in the recommend-min-version value.</li>
-<li>Has the same MAJOR and MINOR version numbers a greater PATCH number.  In this case, "_compatible" and "_non_compatible modifiers"
+<li>Has the exact MAJOR, MINOR, PATCH and "_compatible" or "_non_compatible" modifiers as in the recommend-min-version value.</li>
+<li>Has the same MAJOR and MINOR version numbers and a greater PATCH number.  In this case, "_compatible" and "_non_compatible modifiers"
 are ignored.</li>
 <li>Has the same MAJOR version number and greater MINOR number.  In this case the PATCH number and the "_compatible" and "_non_compatible" modifiers are ignored.</li>
 <li>Has a greater MAJOR version number.  In this case MINOR and PATCH numbers and "_compatible" and "_non_compatible" modifiers are ignored.</li>
 </ol>
-<t>If the recommended-min-version is specified as 3.1.0, the following examples would be viable:</t>
+<t>If the recommended-min-version is specified as 3.1.0, the following examples would be satisfy that recommend-min-version:</t>
 <ul empty="true" spacing="normal">
 <li>3.1.0 (by condition 1 above)</li>
 <li>3.1.1 (by condition 2 above)</li>

--- a/yang-semver/ietf-yang-library-semver.yang
+++ b/yang-semver/ietf-yang-library-semver.yang
@@ -65,8 +65,8 @@ module ietf-yang-library-semver {
   // RFC Ed.: please replace ys:version with 1.0.0 and
   // remove this note.
 
-  revision 2024-03-01 {
-    ys:version "1.0.0-draft-ietf-netmod-yang-semver-13";
+  revision 2024-03-02 {
+    ys:version "1.0.0-draft-ietf-netmod-yang-semver-14";
     description
       "Initial revision";
     reference

--- a/yang-semver/ietf-yang-library-semver.yang
+++ b/yang-semver/ietf-yang-library-semver.yang
@@ -1,0 +1,144 @@
+module ietf-yang-library-semver {
+  yang-version 1.1;
+  namespace
+    "urn:ietf:params:xml:ns:yang:ietf-yang-library-semver";
+  prefix yl-rev;
+
+  import ietf-yang-semver {
+    prefix ys;
+    reference
+      "XXXX: YANG Semantic Versioning";
+  }
+  import ietf-yang-library {
+    prefix yanglib;
+    reference
+      "RFC 8525: YANG Library";
+  }
+
+  organization
+    "IETF NETMOD (Network Modeling) Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     Author:   Joe Clarke
+               <mailto:jclarke@cisco.com>
+
+     Author:   Reshad Rahman
+               <mailto:reshad@yahoo.com>
+
+     Author:   Robert Wilton
+               <mailto:rwilton@cisco.com>
+
+     Author:   Balazs Lengyel
+               <mailto:balazs.lengyel@ericsson.com>
+
+     Author:   Jason Sterne
+               <mailto:jason.sterne@nokia.com>";
+  description
+    "This module contains augmentations to YANG Library to add module
+     and submodule level version identifiers.
+
+     Copyright (c) 2024 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Revised BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC XXXX; see
+     the RFC itself for full legal notices.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.";
+
+  // RFC Ed.: update the date below with the date of RFC publication
+  // and remove this note.
+  // RFC Ed.: replace XXXX (including in the imports above) with
+  // actual RFC number and remove this note.
+  // RFC Ed.: please replace ys:version with 1.0.0 and
+  // remove this note.
+
+  revision 2024-03-01 {
+    ys:version "1.0.0-draft-ietf-netmod-yang-semver-13";
+    description
+      "Initial revision";
+    reference
+      "XXXX: YANG Semantic Versioning";
+  }
+
+  // library 1.0 modules-state is not augmented with version
+
+  augment "/yanglib:yang-library/yanglib:module-set/yanglib:module" {
+    description
+      "Add a version to module information";
+    leaf version {
+      type ys:version;
+      description
+        "The version associated with this module revision.
+         The value MUST match the version value in the
+         specific revision of the module loaded in this module-set.";
+      reference
+        "XXXX: YANG Semantic Versioning;
+         Section 7.1.1, Advertising version";
+    }
+  }
+
+  augment
+    "/yanglib:yang-library/yanglib:module-set/yanglib:module/"
+  + "yanglib:submodule" {
+    description
+      "Add a version to submodule information";
+    leaf version {
+      type ys:version;
+      description
+        "The version associated with this submodule revision.
+         The value MUST match the version value in the
+         specific revision of the submodule included by the module
+         loaded in this module-set.";
+      reference
+        "XXXX: YANG Semantic Versioning;
+         Section 7.1.1, Advertising version";
+    }
+  }
+
+  augment "/yanglib:yang-library/yanglib:module-set/"
+        + "yanglib:import-only-module" {
+    description
+      "Add a version to module information";
+    leaf version {
+      type ys:version;
+      description
+        "The version associated with this module revision.
+         The value MUST match the version value in the
+         specific revision of the module included in this
+         module-set.";
+      reference
+        "XXXX: YANG Semantic Versioning;
+         Section 7.1.1, Advertising version";
+    }
+  }
+
+  augment "/yanglib:yang-library/yanglib:module-set/"
+        + "yanglib:import-only-module/yanglib:submodule" {
+    description
+      "Add a version to submodule information";
+    leaf version {
+      type ys:version;
+      description
+        "The version associated with this submodule revision.
+         The value MUST match the version value in the specific
+         revision of the submodule included by the import-only-module
+         loaded in this module-set.";
+      reference
+        "XXXX: Updated YANG Module Revision Handling;
+         Section 7.1.1, Advertising version";
+    }
+  }
+}

--- a/yang-semver/ietf-yang-library-semver.yang
+++ b/yang-semver/ietf-yang-library-semver.yang
@@ -2,7 +2,7 @@ module ietf-yang-library-semver {
   yang-version 1.1;
   namespace
     "urn:ietf:params:xml:ns:yang:ietf-yang-library-semver";
-  prefix yl-rev;
+  prefix yl-semver;
 
   import ietf-yang-semver {
     prefix ys;

--- a/yang-semver/ietf-yang-semver.yang
+++ b/yang-semver/ietf-yang-semver.yang
@@ -1,7 +1,7 @@
 module ietf-yang-semver {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-semver";
-  prefix ysver;
+  prefix ys;
 
   organization
     "IETF NETMOD (Network Modeling) Working Group";
@@ -48,10 +48,10 @@ module ietf-yang-semver {
   // and remove this note.
   // RFC Ed.: replace XXXX with actual RFC number and remove this
   // note.
-  // RFC Ed. update the ysver:version to "1.0.0".
+  // RFC Ed. update the ysr:version to "1.0.0".
 
   revision 2024-01-22 {
-    ysver:version "1.0.0-draft-ietf-netmod-yang-semver-13";
+    ys:version "1.0.0-draft-ietf-netmod-yang-semver-13";
     description
       "Initial revision";
     reference

--- a/yang-semver/ietf-yang-semver.yang
+++ b/yang-semver/ietf-yang-semver.yang
@@ -48,7 +48,7 @@ module ietf-yang-semver {
   // and remove this note.
   // RFC Ed.: replace XXXX with actual RFC number and remove this
   // note.
-  // RFC Ed. update the ysr:version to "1.0.0".
+  // RFC Ed. update the ys:version to "1.0.0".
 
   revision 2024-01-22 {
     ys:version "1.0.0-draft-ietf-netmod-yang-semver-13";

--- a/yang-semver/ietf-yang-semver.yang
+++ b/yang-semver/ietf-yang-semver.yang
@@ -65,12 +65,12 @@ module ietf-yang-semver {
   extension version {
     argument yang-semantic-version;
     description
-      "The version can be used to provide an additional
+      "The version extension can be used to provide an additional
        identifier associated with a module or submodule
        revision.
 
-       The format of the version extension argument MUST conform to the
-       'version' typedef defined in this module.
+       The format of the version extension argument MUST conform
+       to the 'version' typedef defined in this module.
 
        The statement MUST only be a substatement of the revision
        statement.  Zero or one version statements per parent
@@ -96,8 +96,8 @@ module ietf-yang-semver {
       "Recommends the versions of the module that may be imported to
        one that is greater than or equal to the specified version.
 
-       The format of the version extension argument MUST conform
-       to the 'version' typedef defined in this module.
+       The format of the recommended-min-version extension argument
+       MUST conform to the 'version' typedef defined in this module.
 
        The statement MUST only be a substatement of the import
        statement.  Zero, one or more 'recommended-min-version'

--- a/yang-semver/ietf-yang-semver.yang
+++ b/yang-semver/ietf-yang-semver.yang
@@ -69,11 +69,11 @@ module ietf-yang-semver {
        identifier associated with a module or submodule
        revision.
 
-       The format of the revision label argument MUST conform to the
+       The format of the version extension argument MUST conform to the
        'version' typedef defined in this module.
 
        The statement MUST only be a substatement of the revision
-       statement.  Zero or one revision label statements per parent
+       statement.  Zero or one version statements per parent
        statement are allowed.  No substatements for this extension
        have been standardized.
 
@@ -96,8 +96,8 @@ module ietf-yang-semver {
       "Recommends the versions of the module that may be imported to
        one that is greater than or equal to the specified version.
 
-       The argument value MUST conform to the
-       'version' typedef defined in this module.
+       The format of the version extension argument MUST conform
+       to the 'version' typedef defined in this module.
 
        The statement MUST only be a substatement of the import
        statement.  Zero, one or more 'recommended-min-version'
@@ -139,7 +139,7 @@ module ietf-yang-semver {
     }
     description
       "Represents a YANG semantic version.  The rules governing the
-       use of this revision label scheme are defined in the
+       use of this version identifier are defined in the
        reference for this typedef.";
     reference
       "RFC XXXX: YANG Semantic Versioning.";

--- a/yang-semver/ietf-yang-semver.yang
+++ b/yang-semver/ietf-yang-semver.yang
@@ -2,11 +2,6 @@ module ietf-yang-semver {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-semver";
   prefix ysver;
-  rev:revision-label-scheme "yang-semver";
-
-  import ietf-yang-revisions {
-    prefix rev;
-  }
 
   organization
     "IETF NETMOD (Network Modeling) Working Group";
@@ -30,7 +25,7 @@ module ietf-yang-semver {
     "This module provides type and grouping definitions for YANG
      packages.
 
-     Copyright (c) 2022 IETF Trust and the persons identified as
+     Copyright (c) 2024 IETF Trust and the persons identified as
      authors of the code.  All rights reserved.
 
      Redistribution and use in source and binary forms, with or
@@ -49,8 +44,8 @@ module ietf-yang-semver {
   // note.
   // RFC Ed. update the rev:revision-label to "1.0.0".
 
-  revision 2023-01-17 {
-    rev:label "1.0.0-draft-ietf-netmod-yang-semver-10";
+  revision 2024-01-22 {
+    ysver:version "1.0.0-draft-ietf-netmod-yang-semver-13";
     description
       "Initial revision";
     reference
@@ -58,18 +53,73 @@ module ietf-yang-semver {
   }
 
   /*
-   * Identities
+   * Extensions
    */
 
-  identity yang-semver {
-    base rev:revision-label-scheme-base;
+  extension version {
+    argument yang-semantic-version;
     description
-      "The revision-label scheme corresponds to the YANG Semver
-       scheme which is defined by the pattern in the 'version'
-       typedef below. The rules governing this revision-label
-       scheme are defined in the reference for this identity.";
+      "The version can be used to provide an additional
+       identifier associated with a module or submodule
+       revision.
+
+       The format of the revision label argument MUST conform to the
+       'version' typedef defined in this module.
+
+       The statement MUST only be a substatement of the revision
+       statement.  Zero or one revision label statements per parent
+       statement are allowed.  No substatements for this extension
+       have been standardized.
+
+       Versions MUST be unique amongst all revisions of a
+       module or submodule.
+
+       Adding a version is a backwards-compatible
+       change.  Changing or removing an existing version in
+       the revision history is a non-backwards-compatible
+       change, because it could impact any references to that
+       version.";
     reference
-      "RFC XXXX: YANG Semantic Versioning.";
+      "XXXX: YANG Semantic Versioning;
+       Section 3.2, YANG Semantic Version Extension";
+  }
+
+  extension recommended-min-version {
+    argument yang-semantic-version;
+    description
+      "Recommends the versions of the module that may be imported to
+       one that is greater than or equal to the specified version.
+
+       The argument value MUST conform to the
+       'version' typedef defined in this module.
+
+       The statement MUST only be a substatement of the import
+       statement.  Zero, one or more 'recommended-min-version' 
+       statements per parent statement are allowed.  No 
+       substatements for this extension have been 
+       standardized.
+
+       If specified multiple times, then any module revision that
+       satisfies at least one of the 'recommended-min-version' 
+       statements is an acceptable recommended version for 
+       import.
+
+       A particular version of an imported module adheres to an
+       import's 'recommended-min-version' extension statement if one
+       of the following conditions are met:
+
+       * Has the same MAJOR and MINOR version numbers and same or 
+         greater PATCH number.
+       * Has the same MAJOR version number and greater MINOR number.  
+         In this case the PATCH number is ignored.
+       * Has a greater MAJOR version number.  In this case 
+         MINOR and PATCH numbers are ignored.
+
+       Adding, removing or updating a 'recommended-min-version'
+       statement to an import is a backwards-compatible change.";
+    reference
+      "XXXX: YANG Semantic Versioning; Section 4,
+       Import Module by Semantic Version";
   }
 
   /*
@@ -77,7 +127,7 @@ module ietf-yang-semver {
    */
 
   typedef version {
-    type rev:revision-label {
+    type string {
       pattern '[0-9]+[.][0-9]+[.][0-9]+(_(non_)?compatible)?'
             + '(-[A-Za-z0-9.-]+[.-][0-9]+)?([+][A-Za-z0-9.-]+)?';
     }

--- a/yang-semver/ietf-yang-semver.yang
+++ b/yang-semver/ietf-yang-semver.yang
@@ -35,6 +35,12 @@ module ietf-yang-semver {
      Relating to IETF Documents
      (http://trustee.ietf.org/license-info).
 
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.
+
      This version of this YANG module is part of RFC XXXX; see
      the RFC itself for full legal notices.";
 

--- a/yang-semver/ietf-yang-semver.yang
+++ b/yang-semver/ietf-yang-semver.yang
@@ -50,7 +50,7 @@ module ietf-yang-semver {
   // note.
   // RFC Ed. update the ys:version to "1.0.0".
 
-  revision 2024-01-22 {
+  revision 2024-03-01 {
     ys:version "1.0.0-draft-ietf-netmod-yang-semver-13";
     description
       "Initial revision";

--- a/yang-semver/ietf-yang-semver.yang
+++ b/yang-semver/ietf-yang-semver.yang
@@ -100,25 +100,25 @@ module ietf-yang-semver {
        'version' typedef defined in this module.
 
        The statement MUST only be a substatement of the import
-       statement.  Zero, one or more 'recommended-min-version' 
-       statements per parent statement are allowed.  No 
-       substatements for this extension have been 
+       statement.  Zero, one or more 'recommended-min-version'
+       statements per parent statement are allowed.  No
+       substatements for this extension have been
        standardized.
 
        If specified multiple times, then any module revision that
-       satisfies at least one of the 'recommended-min-version' 
-       statements is an acceptable recommended version for 
+       satisfies at least one of the 'recommended-min-version'
+       statements is an acceptable recommended version for
        import.
 
        A particular version of an imported module adheres to an
        import's 'recommended-min-version' extension statement if one
        of the following conditions are met:
 
-       * Has the same MAJOR and MINOR version numbers and same or 
+       * Has the same MAJOR and MINOR version numbers and same or
          greater PATCH number.
-       * Has the same MAJOR version number and greater MINOR number.  
+       * Has the same MAJOR version number and greater MINOR number.
          In this case the PATCH number is ignored.
-       * Has a greater MAJOR version number.  In this case 
+       * Has a greater MAJOR version number.  In this case
          MINOR and PATCH numbers are ignored.
 
        Adding, removing or updating a 'recommended-min-version'

--- a/yang-semver/ietf-yang-semver.yang
+++ b/yang-semver/ietf-yang-semver.yang
@@ -48,7 +48,7 @@ module ietf-yang-semver {
   // and remove this note.
   // RFC Ed.: replace XXXX with actual RFC number and remove this
   // note.
-  // RFC Ed. update the rev:revision-label to "1.0.0".
+  // RFC Ed. update the ysver:version to "1.0.0".
 
   revision 2024-01-22 {
     ysver:version "1.0.0-draft-ietf-netmod-yang-semver-13";


### PR DESCRIPTION
This does the following:

- Define ysver:version
- Remove revision-label and revision-label-scheme
- Define ysver:recommended-min-version
- Update import rules

This is a first pass, and I expect many issues.  This gives us something to pick apart concretely, though.