### PR TITLE
Address comments from Reshad.

### DIFF
--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -6,18 +6,18 @@ Network Working Group                                     J. Clarke, Ed.
 Internet-Draft                                            R. Wilton, Ed.
 Updates: 8407, 8525, 7950 (if approved)              Cisco Systems, Inc.
 Intended status: Standards Track                               R. Rahman
-Expires: 16 September 2024                                       Equinix
+Expires: 26 December 2024                                        Equinix
                                                               B. Lengyel
                                                                 Ericsson
                                                                J. Sterne
                                                                    Nokia
                                                                B. Claise
                                                                   Huawei
-                                                           15 March 2024
+                                                            24 June 2024
 
 
                         YANG Semantic Versioning
-                    draft-ietf-netmod-yang-semver-15
+                    draft-ietf-netmod-yang-semver-16
 
 Abstract
 
@@ -43,7 +43,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 16 September 2024.
+   This Internet-Draft will expire on 26 December 2024.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Clarke, et al.          Expires 16 September 2024               [Page 1]
+Clarke, et al.          Expires 26 December 2024                [Page 1]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -82,7 +82,7 @@ Table of Contents
        4.4.2.  YANG Semver with submodules . . . . . . . . . . . . .   9
        4.4.3.  Examples for YANG semantic versions . . . . . . . . .   9
      4.5.  YANG Semantic Version Update Rules  . . . . . . . . . . .  11
-     4.6.  Examples of the YANG Semver Label . . . . . . . . . . . .  13
+     4.6.  Examples of the YANG Semver Version Identifier  . . . . .  13
        4.6.1.  Example Module Using YANG Semver  . . . . . . . . . .  13
        4.6.2.  Example of Package Using YANG Semver  . . . . . . . .  14
    5.  Import Module by YANG Semantic Version  . . . . . . . . . . .  15
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Clarke, et al.          Expires 16 September 2024               [Page 2]
+Clarke, et al.          Expires 26 December 2024                [Page 2]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
      13.2.  Informative References . . . . . . . . . . . . . . . . .  30
@@ -120,13 +120,12 @@ Internet-Draft                 YANG Semver                    March 2024
 
 1.  Introduction
 
-   [I-D.ietf-netmod-yang-module-versioning] puts forth a number of
-   concepts relating to modified rules for updating YANG modules and
-   submodules, a means to signal when a new revision of a module or
-   submodule has non-backwards-compatible (NBC) changes compared to its
-   previous revision, and a scheme that uses the revision history as a
-   lineage for determining from where a specific revision of a YANG
-   module or submodule is derived.
+   [I-D.ietf-netmod-yang-module-versioning] puts forth new concepts
+   relating to modified rules for updating YANG modules and submodules,
+   a means to signal when a new revision of a module or submodule has
+   non-backwards-compatible (NBC) changes compared to its previous
+   revision, and a more flexible approach to importing modules by
+   revision.
 
    This document defines a YANG extension that tags a YANG artifact
    (i.e., YANG modules, YANG submodules, and YANG packages
@@ -165,9 +164,10 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024               [Page 3]
+
+Clarke, et al.          Expires 26 December 2024                [Page 3]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
           Module revision date      Example version identifier
@@ -221,9 +221,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024               [Page 4]
+Clarke, et al.          Expires 26 December 2024                [Page 4]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
 4.1.  Relationship Between SemVer and YANG Semver
@@ -240,7 +240,7 @@ Internet-Draft                 YANG Semver                    March 2024
 
    The ietf-yang-semver module defines a "version" extension -- a
    substatement to a module or submodule's "revision" statement -- that
-   takes a YANG semantic version as its argument and specified the
+   takes a YANG semantic version as its argument and specifies the
    version for the given module or submodule.  The syntax for the YANG
    semantic version is defined in a typedef in the same module and
    described below.
@@ -277,9 +277,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024               [Page 5]
+Clarke, et al.          Expires 26 December 2024                [Page 5]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
    Additionally, [SemVer] defines two specific types of metadata that
@@ -333,9 +333,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024               [Page 6]
+Clarke, et al.          Expires 26 December 2024                [Page 6]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
    Every YANG module and submodule versioned using the YANG semantic
@@ -357,8 +357,9 @@ Internet-Draft                 YANG Semver                    March 2024
    of the form: 'X.Y.Z_COMPAT'.
 
    *  'X' is the MAJOR version.  Changes in the MAJOR version number
-      indicate changes that are non-backwards-compatible to versions
-      with a lower MAJOR version number.
+      indicate changes that are non-backwards-compatible (Section 3.1.1
+      of [I-D.ietf-netmod-yang-module-versioning]) to versions with a
+      lower MAJOR version number.
 
    *  'Y' is the MINOR version.  Changes in the MINOR version number
       indicate changes that are backwards-compatible to versions with
@@ -388,10 +389,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-
-Clarke, et al.          Expires 16 September 2024               [Page 7]
+Clarke, et al.          Expires 26 December 2024                [Page 7]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
       -  If the modifier string is absent, the change represents an
@@ -445,9 +445,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024               [Page 8]
+Clarke, et al.          Expires 26 December 2024                [Page 8]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
          3.5.0 -- 3.6.0 (add leaf foo)
@@ -501,9 +501,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024               [Page 9]
+Clarke, et al.          Expires 26 December 2024                [Page 9]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
    YANG Semantic versions for an example module:
@@ -557,9 +557,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 10]
+Clarke, et al.          Expires 26 December 2024               [Page 10]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
       1.3.1_non_compatible - backport NBC fix, rename "baz" to "bar"
@@ -613,9 +613,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 11]
+Clarke, et al.          Expires 26 December 2024               [Page 11]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
    3.  If an artifact is being updated in an editorial way, then the
@@ -669,9 +669,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 12]
+Clarke, et al.          Expires 26 December 2024               [Page 12]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
    [I-D.ietf-netmod-yang-module-versioning] defines the "rev:non-
@@ -684,7 +684,7 @@ Internet-Draft                 YANG Semver                    March 2024
    version has been incremented it does not necessarily mean that a
    "rev:non-backwards-compatible" statement would be present.
 
-4.6.  Examples of the YANG Semver Label
+4.6.  Examples of the YANG Semver Version Identifier
 
 4.6.1.  Example Module Using YANG Semver
 
@@ -725,9 +725,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 13]
+Clarke, et al.          Expires 26 December 2024               [Page 13]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
        revision 2017-02-07 {
@@ -781,9 +781,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 14]
+Clarke, et al.          Expires 26 December 2024               [Page 14]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
    {
@@ -837,9 +837,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 15]
+Clarke, et al.          Expires 26 December 2024               [Page 15]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
            import example-module {
@@ -887,15 +887,15 @@ Internet-Draft                 YANG Semver                    March 2024
 
    If an import by recommended-min-version cannot locate a module with a
    version that is viable according to the conditions above, the YANG
-   compiler SHOULD emit a warning, and then continue to resolve the
+   compiler should emit a warning, and then continue to resolve the
    import based on established [RFC7950] rules.
 
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 16]
+Clarke, et al.          Expires 26 December 2024               [Page 16]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
 6.  Guidelines for Using Semver During Module Development
@@ -949,9 +949,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 17]
+Clarke, et al.          Expires 26 December 2024               [Page 17]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
    development, it is possible that the original intent changes.  For
@@ -1005,9 +1005,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 18]
+Clarke, et al.          Expires 26 December 2024               [Page 18]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
 6.2.1.  Guidelines for IETF Module Development
@@ -1061,9 +1061,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 19]
+Clarke, et al.          Expires 26 December 2024               [Page 19]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
 7.1.  YANG library versioning augmentations
@@ -1117,9 +1117,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 20]
+Clarke, et al.          Expires 26 December 2024               [Page 20]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
         Author:   Robert Wilton
@@ -1173,9 +1173,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 21]
+Clarke, et al.          Expires 26 December 2024               [Page 21]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
       * Extensions
@@ -1229,9 +1229,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 22]
+Clarke, et al.          Expires 26 December 2024               [Page 22]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
           statements is an acceptable recommended version for
@@ -1285,9 +1285,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 23]
+Clarke, et al.          Expires 26 December 2024               [Page 23]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
      import ietf-yang-semver {
@@ -1341,9 +1341,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 24]
+Clarke, et al.          Expires 26 December 2024               [Page 24]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
         The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
@@ -1397,9 +1397,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 25]
+Clarke, et al.          Expires 26 December 2024               [Page 25]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
             specific revision of the submodule included by the module
@@ -1453,9 +1453,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 26]
+Clarke, et al.          Expires 26 December 2024               [Page 26]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
      Bo Wu
@@ -1509,9 +1509,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 27]
+Clarke, et al.          Expires 26 December 2024               [Page 27]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
    That said, the YANG module in this document does not define any
@@ -1565,9 +1565,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 28]
+Clarke, et al.          Expires 26 December 2024               [Page 28]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
 12.2.  Guidance for YANG Semver in IANA maintained YANG modules and
@@ -1621,9 +1621,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 29]
+Clarke, et al.          Expires 26 December 2024               [Page 29]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
    [RFC3688]  Mealling, M., "The IETF XML Registry", BCP 81, RFC 3688,
@@ -1677,9 +1677,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 30]
+Clarke, et al.          Expires 26 December 2024               [Page 30]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
    [I-D.ietf-netmod-yang-packages]
@@ -1733,9 +1733,9 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 31]
+Clarke, et al.          Expires 26 December 2024               [Page 31]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
    [RFC8792]  Watsen, K., Auerswald, E., Farrel, A., and Q. Wu,
@@ -1789,9 +1789,9 @@ Appendix A.  Example IETF Module Development
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 32]
+Clarke, et al.          Expires 26 December 2024               [Page 32]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
        1.0.0-draft-ietf-netmod-example-module-00
@@ -1845,9 +1845,9 @@ Authors' Addresses
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 33]
+Clarke, et al.          Expires 26 December 2024               [Page 33]
 
-Internet-Draft                 YANG Semver                    March 2024
+Internet-Draft                 YANG Semver                     June 2024
 
 
    Joe Clarke (editor)
@@ -1901,4 +1901,4 @@ Internet-Draft                 YANG Semver                    March 2024
 
 
 
-Clarke, et al.          Expires 16 September 2024              [Page 34]
+Clarke, et al.          Expires 26 December 2024               [Page 34]

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" updates="8407,8525,7950" category="std" ipr="trust200902" consensus="true" docName="draft-ietf-netmod-yang-semver-15" xml:lang="en" obsoletes="" submissionType="IETF" version="3">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" updates="8407,8525,7950" category="std" ipr="trust200902" consensus="true" docName="draft-ietf-netmod-yang-semver-16" xml:lang="en" obsoletes="" submissionType="IETF" version="3">
   <front>
     <title abbrev="YANG Semver">YANG Semantic Versioning</title>
-<seriesInfo name="Internet-Draft" value="draft-ietf-netmod-yang-semver-15"/>
+<seriesInfo name="Internet-Draft" value="draft-ietf-netmod-yang-semver-16"/>
 
     <author initials="J." surname="Clarke" fullname="Joe Clarke" role="editor">
       <organization>Cisco Systems, Inc.</organization>
@@ -74,11 +74,11 @@ This document updates RFCs 7950, 8407, and 8525.</t>
       <name>Introduction</name>
       <t>
         <xref target="I-D.ietf-netmod-yang-module-versioning" format="default"/>
- puts forth a number of concepts relating
-   to modified rules for updating YANG modules and submodules, a means to signal when a new revision of a module or submodule has
-   non-backwards-compatible (NBC) changes compared to its previous revision, and a scheme that
-   uses the revision history as a lineage for determining from where a specific revision of a YANG
-module or submodule is derived.</t>
+ puts forth new
+   concepts relating to modified rules for updating YANG modules and
+   submodules, a means to signal when a new revision of a module or
+   submodule has non-backwards-compatible (NBC) changes compared to its
+   previous revision, and a more flexible approach to importing modules by revision.</t>
 <t>This document defines a YANG extension that tags a YANG artifact (i.e., YANG modules, YANG submodules, and YANG packages <xref target="I-D.ietf-netmod-yang-packages" format="default"/>
 )
         with a version identifier that adheres to extended semantic versioning rules <xref target="SemVer" format="default"/>.
@@ -149,7 +149,7 @@ rules (though the inverse is not necessarily true).  YANG Semver is a superset o
   <section anchor="version_extension" numbered="true" toc="default">
 <name>YANG Semantic Version Extension</name>
 <t>The ietf-yang-semver module defines a "version" extension -- a substatement to a module or submodule's "revision" statement -- 
-that takes a YANG semantic version as its argument and specified the version for the given module or submodule.  The syntax for
+that takes a YANG semantic version as its argument and specifies the version for the given module or submodule.  The syntax for
 the YANG semantic version is defined in a typedef in the same module and described below.</t>
 </section>
   <section anchor="version_pattern" numbered="true" toc="default">
@@ -221,7 +221,8 @@ that all revisions of a given YANG artifact will have a semantic version identif
 </t>
 <ul spacing="normal">
 <li>'X' is the MAJOR version.  Changes in the MAJOR version number
-       indicate changes that are non-backwards-compatible to versions
+       indicate changes that are non-backwards-compatible 
+       (<relref section="3.1.1" target="I-D.ietf-netmod-yang-module-versioning" displayFormat="of"/>) to versions
        with a lower MAJOR version number.</li>
 <li>'Y' is the MINOR version.  Changes in the MINOR version number
        indicate changes that are backwards-compatible to versions with
@@ -463,7 +464,7 @@ skipped.</li>
  does not necessarily mean that a "rev:non-backwards-compatible" statement would be present.</t>
 </section>
 <section anchor="examples" numbered="true" toc="default">
-<name>Examples of the YANG Semver Label</name>
+<name>Examples of the YANG Semver Version Identifier</name>
 <section anchor="example_module" numbered="true" toc="default">
 <name>Example Module Using YANG Semver</name>
 <t>Below is a sample YANG module that uses YANG Semver
@@ -609,7 +610,7 @@ are ignored.</li>
 <li>3.1.2_non_compatible (by condition 2 above, noting that modifiers are ignored)</li>
 </ul>
 <t>If an import by recommended-min-version cannot locate a module with a version that is viable according to the conditions above, 
-  the YANG compiler SHOULD emit a warning, and then continue to resolve the import based on established <xref target="RFC7950" format="default"/> rules.</t>
+  the YANG compiler should emit a warning, and then continue to resolve the import based on established <xref target="RFC7950" format="default"/> rules.</t>
 </section>
 </section>
 <section anchor="guidelines" numbered="true" toc="default">


### PR DESCRIPTION
* Adjust intro to match the new scope of YANG module versioning
* Add a reference to Section 3.1.1 in YANG module versioning for non-backwards-compatible
* Remove some perhaps-unneeded 2119 capitalization
* Correct a typo