### PR TITLE
DRAFT: Third wglc feedback

### DIFF
--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -6,14 +6,14 @@ Network Working Group                                     J. Clarke, Ed.
 Internet-Draft                                            R. Wilton, Ed.
 Updates: 8407, 8525, 7950 (if approved)              Cisco Systems, Inc.
 Intended status: Standards Track                               R. Rahman
-Expires: 3 January 2025                                          Equinix
+Expires: 23 May 2025                                             Equinix
                                                               B. Lengyel
                                                                 Ericsson
                                                                J. Sterne
                                                                    Nokia
                                                                B. Claise
                                                                   Huawei
-                                                             2 July 2024
+                                                        19 November 2024
 
 
                         YANG Semantic Versioning
@@ -43,7 +43,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 3 January 2025.
+   This Internet-Draft will expire on 23 May 2025.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Clarke, et al.           Expires 3 January 2025                 [Page 1]
+Clarke, et al.             Expires 23 May 2025                  [Page 1]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -93,7 +93,7 @@ Table of Contents
      6.2.  YANG Semver in IETF Modules . . . . . . . . . . . . . . .  18
        6.2.1.  Guidelines for IETF Module Development  . . . . . . .  19
        6.2.2.  Guidelines for Published IETF Modules . . . . . . . .  19
-   7.  Updates to ietf-yang-library  . . . . . . . . . . . . . . . .  19
+   7.  Updates to ietf-yang-library  . . . . . . . . . . . . . . . .  20
      7.1.  YANG library versioning augmentations . . . . . . . . . .  20
        7.1.1.  Advertising version . . . . . . . . . . . . . . . . .  20
    8.  YANG Modules  . . . . . . . . . . . . . . . . . . . . . . . .  20
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Clarke, et al.           Expires 3 January 2025                 [Page 2]
+Clarke, et al.             Expires 23 May 2025                  [Page 2]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
      13.2.  Informative References . . . . . . . . . . . . . . . . .  30
@@ -165,9 +165,9 @@ Internet-Draft                 YANG Semver                     July 2024
 
 
 
-Clarke, et al.           Expires 3 January 2025                 [Page 3]
+Clarke, et al.             Expires 23 May 2025                  [Page 3]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
           Module revision date      Example version identifier
@@ -221,9 +221,9 @@ Internet-Draft                 YANG Semver                     July 2024
 
 
 
-Clarke, et al.           Expires 3 January 2025                 [Page 4]
+Clarke, et al.             Expires 23 May 2025                  [Page 4]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
 4.1.  Relationship Between SemVer and YANG Semver
@@ -277,9 +277,9 @@ Internet-Draft                 YANG Semver                     July 2024
 
 
 
-Clarke, et al.           Expires 3 January 2025                 [Page 5]
+Clarke, et al.             Expires 23 May 2025                  [Page 5]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
    Additionally, [SemVer] defines two specific types of metadata that
@@ -333,9 +333,9 @@ Internet-Draft                 YANG Semver                     July 2024
 
 
 
-Clarke, et al.           Expires 3 January 2025                 [Page 6]
+Clarke, et al.             Expires 23 May 2025                  [Page 6]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
    Every YANG module and submodule versioned using the YANG semantic
@@ -389,9 +389,9 @@ Internet-Draft                 YANG Semver                     July 2024
 
 
 
-Clarke, et al.           Expires 3 January 2025                 [Page 7]
+Clarke, et al.             Expires 23 May 2025                  [Page 7]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
       -  If the modifier string is absent, the change represents an
@@ -445,9 +445,9 @@ Internet-Draft                 YANG Semver                     July 2024
 
 
 
-Clarke, et al.           Expires 3 January 2025                 [Page 8]
+Clarke, et al.             Expires 23 May 2025                  [Page 8]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
          3.5.0 -- 3.6.0 (add leaf foo)
@@ -501,9 +501,9 @@ Internet-Draft                 YANG Semver                     July 2024
 
 
 
-Clarke, et al.           Expires 3 January 2025                 [Page 9]
+Clarke, et al.             Expires 23 May 2025                  [Page 9]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
             0.1.0
@@ -557,9 +557,9 @@ Internet-Draft                 YANG Semver                     July 2024
 
 
 
-Clarke, et al.           Expires 3 January 2025                [Page 10]
+Clarke, et al.             Expires 23 May 2025                 [Page 10]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
       1.3.1_non_compatible - backport NBC fix, rename "baz" to "bar"
@@ -613,9 +613,9 @@ Internet-Draft                 YANG Semver                     July 2024
 
 
 
-Clarke, et al.           Expires 3 January 2025                [Page 11]
+Clarke, et al.             Expires 23 May 2025                 [Page 11]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
    3.  If an artifact is being updated in an editorial way, then the
@@ -669,9 +669,9 @@ Internet-Draft                 YANG Semver                     July 2024
 
 
 
-Clarke, et al.           Expires 3 January 2025                [Page 12]
+Clarke, et al.             Expires 23 May 2025                 [Page 12]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
    Although YANG Semver always indicates when a non-backwards-
@@ -725,9 +725,9 @@ Internet-Draft                 YANG Semver                     July 2024
 
 
 
-Clarke, et al.           Expires 3 January 2025                [Page 13]
+Clarke, et al.             Expires 23 May 2025                 [Page 13]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
        revision 2017-04-20 {
@@ -781,9 +781,9 @@ Internet-Draft                 YANG Semver                     July 2024
 
 
 
-Clarke, et al.           Expires 3 January 2025                [Page 14]
+Clarke, et al.             Expires 23 May 2025                 [Page 14]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
    {
@@ -828,18 +828,18 @@ Internet-Draft                 YANG Semver                     July 2024
    version of the associated module being imported SHOULD be greater
    than or equal to the specified value.  The specific conditions for
    determining if a module's version is greater than or equal is defined
-   in Section 5.2 below.  Multiple recommended-min-version statements
-   MAY be specified.  If there are multiple recommended-min-version
-   statements, they are treated as a logical OR.  Removing recommended-
-   min-version statements is considered a backwards compatible change.
+   in Section 5.2 below.  At most one instance of recommended-min-
+   version MAY be used.  Removing, adding or changing the recommended-
+   min-version statement is considered a backwards compatible change.
    An example use is:
 
 
 
 
-Clarke, et al.           Expires 3 January 2025                [Page 15]
+
+Clarke, et al.             Expires 23 May 2025                 [Page 15]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
            import example-module {
@@ -848,24 +848,24 @@ Internet-Draft                 YANG Semver                     July 2024
 
 5.2.  Import by YANG Semantic Version Rules
 
-   A module to be imported is considered as meeting the recommended
-   minimum version criteria if it meets one of the following conditions:
+   When evaluating the recommended-min-version extension value as well
+   as the target module to import, only the triple of MAJOR.MINOR.PATCH
+   are considered.  The "_compatible" and "_non_compatible" modifiers as
+   well as any pre-release metadata are ignored.  A module to be
+   imported is considered as meeting the recommended minimum version
+   criteria if it meets one of the following conditions:
 
-   1.  Has the exact MAJOR, MINOR, PATCH and "_compatible" or
-       "_non_compatible" modifiers as in the recommend-min-version
+   1.  Has the exact MAJOR, MINOR, PATCH as in the recommend-min-version
        value.
 
    2.  Has the same MAJOR and MINOR version numbers and a greater PATCH
-       number.  In this case, "_compatible" and "_non_compatible
-       modifiers" are ignored.
+       number.
 
    3.  Has the same MAJOR version number and greater MINOR number.  In
-       this case the PATCH number and the "_compatible" and
-       "_non_compatible" modifiers are ignored.
+       this case the PATCH number is ignored.
 
    4.  Has a greater MAJOR version number.  In this case MINOR and PATCH
-       numbers and "_compatible" and "_non_compatible" modifiers are
-       ignored.
+       numbers are ignored.
 
    If the recommended-min-version is specified as 3.1.0, the following
    examples would satisfy that recommend-min-version:
@@ -884,19 +884,24 @@ Internet-Draft                 YANG Semver                     July 2024
       3.1.2_non_compatible (by condition 2 above, noting that modifiers
       are ignored)
 
+      3.3.0-draft-ietf-netmod-example-module-00 (by condition 3 above,
+      noting that the pre-release metadata is ignored)
+
+
+
+
+
+
+
+Clarke, et al.             Expires 23 May 2025                 [Page 16]
+
+Internet-Draft                 YANG Semver                 November 2024
+
+
    If an import by recommended-min-version cannot locate a module with a
    version that is viable according to the conditions above, the YANG
    compiler should emit a warning, and then continue to resolve the
    import based on established [RFC7950] rules.
-
-
-
-
-
-Clarke, et al.           Expires 3 January 2025                [Page 16]
-
-Internet-Draft                 YANG Semver                     July 2024
-
 
 6.  Guidelines for Using Semver During Module Development
 
@@ -941,19 +946,19 @@ Internet-Draft                 YANG Semver                     July 2024
    compatible changes, the first development MAJOR version component
    must be 2 with some pre-release notation such as -alpha.1, making the
    version 2.0.0-alpha.1.  That said, every publicly available release
+
+
+
+Clarke, et al.             Expires 23 May 2025                 [Page 17]
+
+Internet-Draft                 YANG Semver                 November 2024
+
+
    of a module or submodule MUST have a unique YANG Semver identifier
    (where a publicly available release is one that could be implemented
    by a vendor or consumed by an end user).  Therefore, it may be
    prudent to include the year or year and month development began
    (e.g., 2.0.0-201907-alpha.1).  As a module or submodule undergoes
-
-
-
-Clarke, et al.           Expires 3 January 2025                [Page 17]
-
-Internet-Draft                 YANG Semver                     July 2024
-
-
    development, it is possible that the original intent changes.  For
    example, a 1.0.0 version of a module or submodule that was destined
    to become 2.0.0 after a development cycle may have had a scope change
@@ -992,6 +997,19 @@ Internet-Draft                 YANG Semver                     July 2024
    All published IETF modules and submodules MUST use YANG semantic
    versions in their revisions.
 
+
+
+
+
+
+
+
+
+Clarke, et al.             Expires 23 May 2025                 [Page 18]
+
+Internet-Draft                 YANG Semver                 November 2024
+
+
    Development of a new module or submodule within the IETF SHOULD begin
    with the 0 MAJOR number scheme as described above.  When revising an
    existing IETF module or submodule, the version MUST use the target
@@ -999,16 +1017,6 @@ Internet-Draft                 YANG Semver                     July 2024
    version number.  If the intended RFC release will be non-backwards-
    compatible with the current RFC release, the MINOR version number
    MUST be 0.
-
-
-
-
-
-
-Clarke, et al.           Expires 3 January 2025                [Page 18]
-
-Internet-Draft                 YANG Semver                     July 2024
-
 
 6.2.1.  Guidelines for IETF Module Development
 
@@ -1048,23 +1056,22 @@ Internet-Draft                 YANG Semver                     July 2024
    1.2.0 (since 1.0.0 would have been the initial, pre-NMDA release, and
    1.1.0 would have been the NMDA revision).
 
+
+
+
+
+
+Clarke, et al.             Expires 23 May 2025                 [Page 19]
+
+Internet-Draft                 YANG Semver                 November 2024
+
+
 7.  Updates to ietf-yang-library
 
    This document updates YANG 1.1 [RFC7950] and YANG library [RFC8525]
    to clarify how ambiguous module imports are resolved.  It also
    defines the YANG module, ietf-yang-library-semver, that augments YANG
    library [RFC8525] with a version leaf for modules and submodules.
-
-
-
-
-
-
-
-Clarke, et al.           Expires 3 January 2025                [Page 19]
-
-Internet-Draft                 YANG Semver                     July 2024
-
 
 7.1.  YANG library versioning augmentations
 
@@ -1100,13 +1107,21 @@ Internet-Draft                 YANG Semver                     July 2024
    This YANG module contains the typedef for the YANG semantic version
    and the identity to signal its use.
 
-   <CODE BEGINS> file "ietf-yang-semver@2024-07-02.yang"
+   <CODE BEGINS> file "ietf-yang-semver@2024-11-19.yang"
    module ietf-yang-semver {
      yang-version 1.1;
      namespace "urn:ietf:params:xml:ns:yang:ietf-yang-semver";
      prefix ys;
 
      organization
+
+
+
+Clarke, et al.             Expires 23 May 2025                 [Page 20]
+
+Internet-Draft                 YANG Semver                 November 2024
+
+
        "IETF NETMOD (Network Modeling) Working Group";
      contact
        "WG Web:   <http://tools.ietf.org/wg/netmod/>
@@ -1114,14 +1129,6 @@ Internet-Draft                 YANG Semver                     July 2024
 
         Author:   Joe Clarke
                   <mailto:jclarke@cisco.com>
-
-
-
-Clarke, et al.           Expires 3 January 2025                [Page 20]
-
-Internet-Draft                 YANG Semver                     July 2024
-
-
         Author:   Robert Wilton
                   <mailto:rwilton@cisco.com>
         Author:   Reshad Rahman
@@ -1161,8 +1168,16 @@ Internet-Draft                 YANG Semver                     July 2024
      // note.
      // RFC Ed. update the ys:version to "1.0.0".
 
-     revision 2024-07-02 {
-       ys:version "1.0.0-draft-ietf-netmod-yang-semver-17";
+     revision 2024-11-19 {
+       ys:version "1.0.0-draft-ietf-netmod-yang-semver-18";
+
+
+
+Clarke, et al.             Expires 23 May 2025                 [Page 21]
+
+Internet-Draft                 YANG Semver                 November 2024
+
+
        description
          "Initial revision";
        reference
@@ -1170,14 +1185,6 @@ Internet-Draft                 YANG Semver                     July 2024
      }
 
      /*
-
-
-
-Clarke, et al.           Expires 3 January 2025                [Page 21]
-
-Internet-Draft                 YANG Semver                     July 2024
-
-
       * Extensions
       */
 
@@ -1217,42 +1224,36 @@ Internet-Draft                 YANG Semver                     July 2024
 
           The format of the recommended-min-version extension argument
           MUST conform to the 'version' typedef defined in this module.
+          However, '_compatible' and '_non_compatible' modifiers as
+          well as pre-release metadata are ignored for the
+
+
+
+Clarke, et al.             Expires 23 May 2025                 [Page 22]
+
+Internet-Draft                 YANG Semver                 November 2024
+
+
+          comparisions.
 
           The statement MUST only be a substatement of the import
-          statement.  Zero, one or more 'recommended-min-version'
+          statement.  Zero or one 'recommended-min-version'
           statements per parent statement are allowed.  No
           substatements for this extension have been
           standardized.
-
-          If specified multiple times, then any module revision that
-          satisfies at least one of the 'recommended-min-version'
-
-
-
-Clarke, et al.           Expires 3 January 2025                [Page 22]
-
-Internet-Draft                 YANG Semver                     July 2024
-
-
-          statements is an acceptable recommended version for
-          import.
 
           A module to be imported is considered as meeting the
           recommended minimum version criteria if it meets one of
           the following conditions:
 
-          * Has the exact MAJOR, MINOR, PATCH and '_compatible' or
-            '_non_compatible' modifiers as in the
+          * Has the exact MAJOR, MINOR, PATCH as in the
              recommend-min-version value.
           * Has the same MAJOR and MINOR version numbers and a
-            greater PATCH number.  In this case, '_compatible' and
-            '_non_compatible modifiers' are ignored.
+            greater PATCH number.
           * Has the same MAJOR version number and greater MINOR number.
-            In this case the PATCH number and the '_compatible' and
-            '_non_compatible' modifiers are ignored.
+            In this case the PATCH number is ignored.
           * Has a greater MAJOR version number.  In this case MINOR
-            and PATCH numbers and '_compatible' and '_non_compatible'
-            modifiers are ignored.
+            and PATCH numbers are ignored.
 
           Adding, removing or updating a 'recommended-min-version'
           statement to an import is a backwards-compatible change.";
@@ -1267,6 +1268,7 @@ Internet-Draft                 YANG Semver                     July 2024
 
      typedef version {
        type string {
+         length "5..128";
          pattern '[0-9]+[.][0-9]+[.][0-9]+(_(non_)?compatible)?'
                + '(-[A-Za-z0-9.-]+[.-][0-9]+)?([+][A-Za-z0-9.-]+)?';
        }
@@ -1280,15 +1282,15 @@ Internet-Draft                 YANG Semver                     July 2024
    }
    <CODE ENDS>
 
-   This YANG module contains the augmentations to the ietf-yang-library.
 
 
 
-
-Clarke, et al.           Expires 3 January 2025                [Page 23]
+Clarke, et al.             Expires 23 May 2025                 [Page 23]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
+
+   This YANG module contains the augmentations to the ietf-yang-library.
 
    <CODE BEGINS> file "ietf-yang-library-semver@2024-03-02.yang"
    module ietf-yang-library-semver {
@@ -1336,16 +1338,16 @@ Internet-Draft                 YANG Semver                     July 2024
         authors of the code.  All rights reserved.
 
         Redistribution and use in source and binary forms, with or
+
+
+
+Clarke, et al.             Expires 23 May 2025                 [Page 24]
+
+Internet-Draft                 YANG Semver                 November 2024
+
+
         without modification, is permitted pursuant to, and subject
         to the license terms contained in, the Revised BSD License
-
-
-
-Clarke, et al.           Expires 3 January 2025                [Page 24]
-
-Internet-Draft                 YANG Semver                     July 2024
-
-
         set forth in Section 4.c of the IETF Trust's Legal Provisions
         Relating to IETF Documents
         (http://trustee.ietf.org/license-info).
@@ -1392,16 +1394,16 @@ Internet-Draft                 YANG Semver                     July 2024
      }
 
      augment
+
+
+
+Clarke, et al.             Expires 23 May 2025                 [Page 25]
+
+Internet-Draft                 YANG Semver                 November 2024
+
+
        "/yanglib:yang-library/yanglib:module-set/yanglib:module/"
      + "yanglib:submodule" {
-
-
-
-Clarke, et al.           Expires 3 January 2025                [Page 25]
-
-Internet-Draft                 YANG Semver                     July 2024
-
-
        description
          "Add a version to submodule information";
        leaf version {
@@ -1448,16 +1450,16 @@ Internet-Draft                 YANG Semver                     July 2024
          reference
            "XXXX: Updated YANG Module Revision Handling;
             Section 7.1.1, Advertising version";
+
+
+
+Clarke, et al.             Expires 23 May 2025                 [Page 26]
+
+Internet-Draft                 YANG Semver                 November 2024
+
+
        }
      }
-
-
-
-Clarke, et al.           Expires 3 January 2025                [Page 26]
-
-Internet-Draft                 YANG Semver                     July 2024
-
-
    }
    <CODE ENDS>
 
@@ -1504,15 +1506,15 @@ Internet-Draft                 YANG Semver                     July 2024
    is the secure transport layer, and the mandatory-to-implement secure
    transport is Secure Shell (SSH) [RFC6242].  The lowest RESTCONF layer
    is HTTPS, and the mandatory-to-implement secure transport is TLS
-   [RFC8446].
 
 
 
-
-Clarke, et al.           Expires 3 January 2025                [Page 27]
+Clarke, et al.             Expires 23 May 2025                 [Page 27]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
+
+   [RFC8446].
 
    The NETCONF access control model [RFC8341] provides the means to
    restrict access for particular NETCONF or RESTCONF users to a
@@ -1563,11 +1565,9 @@ Internet-Draft                 YANG Semver                     July 2024
 
 
 
-
-
-Clarke, et al.           Expires 3 January 2025                [Page 28]
+Clarke, et al.             Expires 23 May 2025                 [Page 28]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
       XML Namespace: urn:ietf:params:xml:ns:yang:ietf-yang-library-
@@ -1621,9 +1621,9 @@ Internet-Draft                 YANG Semver                     July 2024
 
 
 
-Clarke, et al.           Expires 3 January 2025                [Page 29]
+Clarke, et al.             Expires 23 May 2025                 [Page 29]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
@@ -1662,9 +1662,9 @@ Internet-Draft                 YANG Semver                     July 2024
               Wilton, R., Rahman, R., Lengyel, B., Clarke, J., and J.
               Sterne, "Updated YANG Module Revision Handling", Work in
               Progress, Internet-Draft, draft-ietf-netmod-yang-module-
-              versioning-11, 1 March 2024,
+              versioning-12, 24 June 2024,
               <https://datatracker.ietf.org/doc/html/draft-ietf-netmod-
-              yang-module-versioning-11>.
+              yang-module-versioning-12>.
 
 13.2.  Informative References
 
@@ -1677,17 +1677,17 @@ Internet-Draft                 YANG Semver                     July 2024
 
 
 
-Clarke, et al.           Expires 3 January 2025                [Page 30]
+Clarke, et al.             Expires 23 May 2025                 [Page 30]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
    [I-D.ietf-netmod-yang-packages]
               Wilton, R., Rahman, R., Clarke, J., Sterne, J., and B. Wu,
               "YANG Packages", Work in Progress, Internet-Draft, draft-
-              ietf-netmod-yang-packages-03, 4 March 2022,
+              ietf-netmod-yang-packages-04, 21 October 2024,
               <https://datatracker.ietf.org/doc/html/draft-ietf-netmod-
-              yang-packages-03>.
+              yang-packages-04>.
 
    [I-D.ietf-netmod-yang-schema-comparison]
               Andersson, P. and R. Wilton, "YANG Schema Comparison",
@@ -1733,9 +1733,9 @@ Internet-Draft                 YANG Semver                     July 2024
 
 
 
-Clarke, et al.           Expires 3 January 2025                [Page 31]
+Clarke, et al.             Expires 23 May 2025                 [Page 31]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
    [RFC8792]  Watsen, K., Auerswald, E., Farrel, A., and Q. Wu,
@@ -1789,9 +1789,9 @@ Appendix A.  Example IETF Module Development
 
 
 
-Clarke, et al.           Expires 3 January 2025                [Page 32]
+Clarke, et al.             Expires 23 May 2025                 [Page 32]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
        1.0.0-draft-ietf-netmod-example-module-00
@@ -1845,9 +1845,9 @@ Authors' Addresses
 
 
 
-Clarke, et al.           Expires 3 January 2025                [Page 33]
+Clarke, et al.             Expires 23 May 2025                 [Page 33]
 
-Internet-Draft                 YANG Semver                     July 2024
+Internet-Draft                 YANG Semver                 November 2024
 
 
    Joe Clarke (editor)
@@ -1901,4 +1901,4 @@ Internet-Draft                 YANG Semver                     July 2024
 
 
 
-Clarke, et al.           Expires 3 January 2025                [Page 34]
+Clarke, et al.             Expires 23 May 2025                 [Page 34]

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -764,7 +764,7 @@ module: ietf-yang-library-semver
 <section anchor="yang_modules" numbered="true" toc="default">
 <name>YANG Modules</name>
 <t>This YANG module contains the typedef for the YANG semantic version and the identity to signal its use.</t>
-<sourcecode name="ietf-yang-semver@2024-11-19.yang" type="" markers="true"><![CDATA[
+<sourcecode name="ietf-yang-semver@2024-11-19.yang" type="yang" markers="true"><![CDATA[
 module ietf-yang-semver {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-semver";
@@ -915,7 +915,7 @@ module ietf-yang-semver {
 }
     ]]></sourcecode>
 <t>This YANG module contains the augmentations to the ietf-yang-library.</t>
-<sourcecode name="ietf-yang-library-semver@2024-03-02.yang" type="" markers="true"><![CDATA[
+<sourcecode name="ietf-yang-library-semver@2024-03-02.yang" type="yang" markers="true"><![CDATA[
 module ietf-yang-library-semver {
   yang-version 1.1;
   namespace

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -580,11 +580,10 @@ imports are resolved.</t>
 that takes a YANG semantic version as its argument and specifies
 that the minimum version of the associated module being imported SHOULD be greater than or equal to the specified
 value.  The specific conditions for determining if a module's version is greater than or equal is defined in
-<xref target="semver_import_rules" format="default"/> below.  Multiple recommended-min-version statements 
-MAY be specified.  If there are multiple
-recommended-min-version statements, they are treated as a logical OR.  Removing recommended-min-version
-statements is considered a backwards compatible change.  An example use is:</t>
-<artwork name="" type="" align="left" alt=""><![CDATA[
+<xref target="semver_import_rules" format="default"/> below.  At most one instance of recommended-min-version MAY be used.  
+Removing, adding or changing the recommended-min-version
+statement is considered a backwards compatible change.  An example use is:</t>
+<artwork name="example-recommended-min-version" type="" align="left" alt=""><![CDATA[
         import example-module {
             ys:recommended-min-version 3.0.0;
         }
@@ -592,13 +591,14 @@ statements is considered a backwards compatible change.  An example use is:</t>
 </section>
 <section anchor="semver_import_rules" numbered="true" toc="default">
 <name>Import by YANG Semantic Version Rules</name>
-<t>A module to be imported is considered as meeting the recommended minimum version criteria if it meets one of the following conditions:</t>
+<t>When evaluating the recommended-min-version extension value as well as the target module to import, only the triple of MAJOR.MINOR.PATCH are considered.
+The "_compatible" and "_non_compatible" modifiers as well as any pre-release metadata are ignored.
+ A module to be imported is considered as meeting the recommended minimum version criteria if it meets one of the following conditions:</t>
 <ol type="1" spacing="normal">
-<li>Has the exact MAJOR, MINOR, PATCH and "_compatible" or "_non_compatible" modifiers as in the recommend-min-version value.</li>
-<li>Has the same MAJOR and MINOR version numbers and a greater PATCH number.  In this case, "_compatible" and "_non_compatible modifiers"
-are ignored.</li>
-<li>Has the same MAJOR version number and greater MINOR number.  In this case the PATCH number and the "_compatible" and "_non_compatible" modifiers are ignored.</li>
-<li>Has a greater MAJOR version number.  In this case MINOR and PATCH numbers and "_compatible" and "_non_compatible" modifiers are ignored.</li>
+<li>Has the exact MAJOR, MINOR, PATCH as in the recommend-min-version value.</li>
+<li>Has the same MAJOR and MINOR version numbers and a greater PATCH number.</li>
+<li>Has the same MAJOR version number and greater MINOR number.  In this case the PATCH number is ignored.</li>
+<li>Has a greater MAJOR version number.  In this case MINOR and PATCH numbers are ignored.</li>
 </ol>
 <t>If the recommended-min-version is specified as 3.1.0, the following examples would satisfy that recommend-min-version:</t>
 <ul empty="true" spacing="normal">
@@ -608,6 +608,7 @@ are ignored.</li>
 <li>4.1.2 (by condition 4 above)</li>
 <li>3.1.1_compatible (by condition 2 above, noting that modifiers are ignored)</li>
 <li>3.1.2_non_compatible (by condition 2 above, noting that modifiers are ignored)</li>
+<li>3.3.0-draft-ietf-netmod-example-module-00 (by condition 3 above, noting that the pre-release metadata is ignored)</li>
 </ul>
 <t>If an import by recommended-min-version cannot locate a module with a version that is viable according to the conditions above, 
   the YANG compiler should emit a warning, and then continue to resolve the import based on established <xref target="RFC7950" format="default"/> rules.</t>
@@ -763,7 +764,7 @@ module: ietf-yang-library-semver
 <section anchor="yang_modules" numbered="true" toc="default">
 <name>YANG Modules</name>
 <t>This YANG module contains the typedef for the YANG semantic version and the identity to signal its use.</t>
-<sourcecode name="ietf-yang-semver@2024-07-02.yang" type="" markers="true"><![CDATA[
+<sourcecode name="ietf-yang-semver@2024-11-19.yang" type="" markers="true"><![CDATA[
 module ietf-yang-semver {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-semver";
@@ -816,8 +817,8 @@ module ietf-yang-semver {
   // note.
   // RFC Ed. update the ys:version to "1.0.0".
 
-  revision 2024-07-02 {
-    ys:version "1.0.0-draft-ietf-netmod-yang-semver-17";
+  revision 2024-11-19 {
+    ys:version "1.0.0-draft-ietf-netmod-yang-semver-18";
     description
       "Initial revision";
     reference
@@ -864,34 +865,28 @@ module ietf-yang-semver {
 
        The format of the recommended-min-version extension argument
        MUST conform to the 'version' typedef defined in this module.
+       However, '_compatible' and '_non_compatible' modifiers as
+       well as pre-release metadata are ignored for the
+       comparisions.
 
        The statement MUST only be a substatement of the import
-       statement.  Zero, one or more 'recommended-min-version'
+       statement.  Zero or one 'recommended-min-version'
        statements per parent statement are allowed.  No
        substatements for this extension have been
        standardized.
-
-       If specified multiple times, then any module revision that
-       satisfies at least one of the 'recommended-min-version'
-       statements is an acceptable recommended version for
-       import.
 
        A module to be imported is considered as meeting the
        recommended minimum version criteria if it meets one of
        the following conditions:
 
-       * Has the exact MAJOR, MINOR, PATCH and '_compatible' or
-         '_non_compatible' modifiers as in the
+       * Has the exact MAJOR, MINOR, PATCH as in the
           recommend-min-version value.
        * Has the same MAJOR and MINOR version numbers and a
-         greater PATCH number.  In this case, '_compatible' and
-         '_non_compatible modifiers' are ignored.
+         greater PATCH number.
        * Has the same MAJOR version number and greater MINOR number.
-         In this case the PATCH number and the '_compatible' and
-         '_non_compatible' modifiers are ignored.
+         In this case the PATCH number is ignored.
        * Has a greater MAJOR version number.  In this case MINOR
-         and PATCH numbers and '_compatible' and '_non_compatible'
-         modifiers are ignored.
+         and PATCH numbers are ignored.
 
        Adding, removing or updating a 'recommended-min-version'
        statement to an import is a backwards-compatible change.";
@@ -906,6 +901,7 @@ module ietf-yang-semver {
 
   typedef version {
     type string {
+      length "5..128";
       pattern '[0-9]+[.][0-9]+[.][0-9]+(_(non_)?compatible)?'
             + '(-[A-Za-z0-9.-]+[.-][0-9]+)?([+][A-Za-z0-9.-]+)?';
     }

--- a/yang-semver/ietf-yang-semver.yang
+++ b/yang-semver/ietf-yang-semver.yang
@@ -50,8 +50,8 @@ module ietf-yang-semver {
   // note.
   // RFC Ed. update the ys:version to "1.0.0".
 
-  revision 2024-07-02 {
-    ys:version "1.0.0-draft-ietf-netmod-yang-semver-17";
+  revision 2024-11-19 {
+    ys:version "1.0.0-draft-ietf-netmod-yang-semver-18";
     description
       "Initial revision";
     reference
@@ -98,34 +98,28 @@ module ietf-yang-semver {
 
        The format of the recommended-min-version extension argument
        MUST conform to the 'version' typedef defined in this module.
+       However, '_compatible' and '_non_compatible' modifiers as
+       well as pre-release metadata are ignored for the
+       comparisions.
 
        The statement MUST only be a substatement of the import
-       statement.  Zero, one or more 'recommended-min-version'
+       statement.  Zero or one 'recommended-min-version'
        statements per parent statement are allowed.  No
        substatements for this extension have been
        standardized.
-
-       If specified multiple times, then any module revision that
-       satisfies at least one of the 'recommended-min-version'
-       statements is an acceptable recommended version for
-       import.
 
        A module to be imported is considered as meeting the
        recommended minimum version criteria if it meets one of
        the following conditions:
 
-       * Has the exact MAJOR, MINOR, PATCH and '_compatible' or
-         '_non_compatible' modifiers as in the
+       * Has the exact MAJOR, MINOR, PATCH as in the
           recommend-min-version value.
        * Has the same MAJOR and MINOR version numbers and a
-         greater PATCH number.  In this case, '_compatible' and
-         '_non_compatible modifiers' are ignored.
+         greater PATCH number.
        * Has the same MAJOR version number and greater MINOR number.
-         In this case the PATCH number and the '_compatible' and
-         '_non_compatible' modifiers are ignored.
+         In this case the PATCH number is ignored.
        * Has a greater MAJOR version number.  In this case MINOR
-         and PATCH numbers and '_compatible' and '_non_compatible'
-         modifiers are ignored.
+         and PATCH numbers are ignored.
 
        Adding, removing or updating a 'recommended-min-version'
        statement to an import is a backwards-compatible change.";

--- a/yang-semver/ietf-yang-semver.yang
+++ b/yang-semver/ietf-yang-semver.yang
@@ -140,6 +140,7 @@ module ietf-yang-semver {
 
   typedef version {
     type string {
+      length "5..128";
       pattern '[0-9]+[.][0-9]+[.][0-9]+(_(non_)?compatible)?'
             + '(-[A-Za-z0-9.-]+[.-][0-9]+)?([+][A-Za-z0-9.-]+)?';
     }


### PR DESCRIPTION
Address some of the feedback from the third WG LC:

* Limit the size of a YANG Semver identifier to 128 characters
* Simplify the rules for `recommended-min-version` matching so that we only look at the Semver triple
* Limit the use of recommended-min-version to 0 or 1