### PR TITLE
Packages: Fix issue link in section 2.3

### DIFF
--- a/yang-packages/draft-ietf-netmod-yang-packages.txt
+++ b/yang-packages/draft-ietf-netmod-yang-packages.txt
@@ -5,12 +5,12 @@
 Network Working Group                                     R. Wilton, Ed.
 Internet-Draft                                       Cisco Systems, Inc.
 Intended status: Standards Track                               R. Rahman
-Expires: 3 September 2026                                        Equinix
+Expires: 4 September 2026                                        Equinix
                                                                J. Clarke
                                                      Cisco Systems, Inc.
                                                                J. Sterne
                                                                    Nokia
-                                                            2 March 2026
+                                                            3 March 2026
 
 
                              YANG Packages
@@ -37,7 +37,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 3 September 2026.
+   This Internet-Draft will expire on 4 September 2026.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Wilton, et al.          Expires 3 September 2026                [Page 1]
+Wilton, et al.          Expires 4 September 2026                [Page 1]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Wilton, et al.          Expires 3 September 2026                [Page 2]
+Wilton, et al.          Expires 4 September 2026                [Page 2]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -165,7 +165,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026                [Page 3]
+Wilton, et al.          Expires 4 September 2026                [Page 3]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -221,7 +221,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026                [Page 4]
+Wilton, et al.          Expires 4 September 2026                [Page 4]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -277,7 +277,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026                [Page 5]
+Wilton, et al.          Expires 4 September 2026                [Page 5]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -333,7 +333,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026                [Page 6]
+Wilton, et al.          Expires 4 September 2026                [Page 6]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -365,7 +365,7 @@ Internet-Draft                YANG Packages                   March 2026
    RFC Editor, please remove this section before publication.
 
    All issues, along with the draft text, are currently being tracked at
-   https://github.com/rgwilton/YANG-Packages-Draft/issues/
+   https://github.com/netmod-wg/yang-ver-dt/issues/
 
 3.  The YANG Package Definition
 
@@ -389,7 +389,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026                [Page 7]
+Wilton, et al.          Expires 4 September 2026                [Page 7]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -445,7 +445,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026                [Page 8]
+Wilton, et al.          Expires 4 September 2026                [Page 8]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -501,7 +501,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026                [Page 9]
+Wilton, et al.          Expires 4 September 2026                [Page 9]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -557,7 +557,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 10]
+Wilton, et al.          Expires 4 September 2026               [Page 10]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -613,7 +613,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 11]
+Wilton, et al.          Expires 4 September 2026               [Page 11]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -669,7 +669,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 12]
+Wilton, et al.          Expires 4 September 2026               [Page 12]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -725,7 +725,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 13]
+Wilton, et al.          Expires 4 September 2026               [Page 13]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -781,7 +781,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 14]
+Wilton, et al.          Expires 4 September 2026               [Page 14]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -837,7 +837,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 15]
+Wilton, et al.          Expires 4 September 2026               [Page 15]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -893,7 +893,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 16]
+Wilton, et al.          Expires 4 September 2026               [Page 16]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -949,7 +949,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 17]
+Wilton, et al.          Expires 4 September 2026               [Page 17]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -1005,7 +1005,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 18]
+Wilton, et al.          Expires 4 September 2026               [Page 18]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -1061,7 +1061,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 19]
+Wilton, et al.          Expires 4 September 2026               [Page 19]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -1117,7 +1117,7 @@ module: ietf-yang-inst-data-pkg
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 20]
+Wilton, et al.          Expires 4 September 2026               [Page 20]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -1173,7 +1173,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 21]
+Wilton, et al.          Expires 4 September 2026               [Page 21]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -1229,7 +1229,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 22]
+Wilton, et al.          Expires 4 September 2026               [Page 22]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -1285,7 +1285,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 23]
+Wilton, et al.          Expires 4 September 2026               [Page 23]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -1341,7 +1341,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 24]
+Wilton, et al.          Expires 4 September 2026               [Page 24]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -1397,7 +1397,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 25]
+Wilton, et al.          Expires 4 September 2026               [Page 25]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -1453,7 +1453,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 26]
+Wilton, et al.          Expires 4 September 2026               [Page 26]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -1509,7 +1509,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 27]
+Wilton, et al.          Expires 4 September 2026               [Page 27]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -1565,7 +1565,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 28]
+Wilton, et al.          Expires 4 September 2026               [Page 28]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -1621,7 +1621,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 29]
+Wilton, et al.          Expires 4 September 2026               [Page 29]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -1677,7 +1677,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 30]
+Wilton, et al.          Expires 4 September 2026               [Page 30]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -1733,7 +1733,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 31]
+Wilton, et al.          Expires 4 September 2026               [Page 31]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -1789,7 +1789,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 32]
+Wilton, et al.          Expires 4 September 2026               [Page 32]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -1845,7 +1845,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 33]
+Wilton, et al.          Expires 4 September 2026               [Page 33]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -1901,7 +1901,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 34]
+Wilton, et al.          Expires 4 September 2026               [Page 34]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -1957,7 +1957,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 35]
+Wilton, et al.          Expires 4 September 2026               [Page 35]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -2013,7 +2013,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 36]
+Wilton, et al.          Expires 4 September 2026               [Page 36]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -2069,7 +2069,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 37]
+Wilton, et al.          Expires 4 September 2026               [Page 37]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -2125,7 +2125,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 38]
+Wilton, et al.          Expires 4 September 2026               [Page 38]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -2181,7 +2181,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 39]
+Wilton, et al.          Expires 4 September 2026               [Page 39]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -2237,7 +2237,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 40]
+Wilton, et al.          Expires 4 September 2026               [Page 40]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -2293,7 +2293,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 41]
+Wilton, et al.          Expires 4 September 2026               [Page 41]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -2349,7 +2349,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 42]
+Wilton, et al.          Expires 4 September 2026               [Page 42]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -2405,7 +2405,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 43]
+Wilton, et al.          Expires 4 September 2026               [Page 43]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -2461,7 +2461,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 44]
+Wilton, et al.          Expires 4 September 2026               [Page 44]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -2517,7 +2517,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 45]
+Wilton, et al.          Expires 4 September 2026               [Page 45]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -2573,7 +2573,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 46]
+Wilton, et al.          Expires 4 September 2026               [Page 46]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -2629,7 +2629,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 47]
+Wilton, et al.          Expires 4 September 2026               [Page 47]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -2685,7 +2685,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 48]
+Wilton, et al.          Expires 4 September 2026               [Page 48]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -2741,7 +2741,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 49]
+Wilton, et al.          Expires 4 September 2026               [Page 49]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -2797,7 +2797,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 50]
+Wilton, et al.          Expires 4 September 2026               [Page 50]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -2853,7 +2853,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 51]
+Wilton, et al.          Expires 4 September 2026               [Page 51]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -2909,7 +2909,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 52]
+Wilton, et al.          Expires 4 September 2026               [Page 52]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -2965,7 +2965,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 53]
+Wilton, et al.          Expires 4 September 2026               [Page 53]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -3021,7 +3021,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 54]
+Wilton, et al.          Expires 4 September 2026               [Page 54]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -3077,7 +3077,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 55]
+Wilton, et al.          Expires 4 September 2026               [Page 55]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -3133,7 +3133,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 56]
+Wilton, et al.          Expires 4 September 2026               [Page 56]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -3189,7 +3189,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 57]
+Wilton, et al.          Expires 4 September 2026               [Page 57]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -3245,7 +3245,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 58]
+Wilton, et al.          Expires 4 September 2026               [Page 58]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -3301,7 +3301,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 59]
+Wilton, et al.          Expires 4 September 2026               [Page 59]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -3357,7 +3357,7 @@ A.1.1.  Example IETF Basic Types YANG package, version 1.0.0
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 60]
+Wilton, et al.          Expires 4 September 2026               [Page 60]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -3413,7 +3413,7 @@ A.1.2.  Example IETF Basic Types YANG package, version 1.1.0
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 61]
+Wilton, et al.          Expires 4 September 2026               [Page 61]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -3469,7 +3469,7 @@ A.1.3.  Example IETF Network Device YANG package
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 62]
+Wilton, et al.          Expires 4 September 2026               [Page 62]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -3525,7 +3525,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 63]
+Wilton, et al.          Expires 4 September 2026               [Page 63]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -3581,7 +3581,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 64]
+Wilton, et al.          Expires 4 September 2026               [Page 64]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -3637,7 +3637,7 @@ A.1.4.  Example IETF Basic Routing YANG package
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 65]
+Wilton, et al.          Expires 4 September 2026               [Page 65]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -3693,7 +3693,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 66]
+Wilton, et al.          Expires 4 September 2026               [Page 66]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -3749,7 +3749,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 67]
+Wilton, et al.          Expires 4 September 2026               [Page 67]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -3805,7 +3805,7 @@ A.3.1.  Example of package import conflict resolution
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 68]
+Wilton, et al.          Expires 4 September 2026               [Page 68]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -3861,7 +3861,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 69]
+Wilton, et al.          Expires 4 September 2026               [Page 69]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -3917,7 +3917,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 70]
+Wilton, et al.          Expires 4 September 2026               [Page 70]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -3973,7 +3973,7 @@ A.4.1.  Example of excluding modules and a mandatory feature
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 71]
+Wilton, et al.          Expires 4 September 2026               [Page 71]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -4029,7 +4029,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 72]
+Wilton, et al.          Expires 4 September 2026               [Page 72]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -4085,7 +4085,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 73]
+Wilton, et al.          Expires 4 September 2026               [Page 73]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -4141,7 +4141,7 @@ Internet-Draft                YANG Packages                   March 2026
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 74]
+Wilton, et al.          Expires 4 September 2026               [Page 74]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -4197,7 +4197,7 @@ A.6.2.  Example of an package replacing the mounted schema
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 75]
+Wilton, et al.          Expires 4 September 2026               [Page 75]
 
 Internet-Draft                YANG Packages                   March 2026
 
@@ -4253,4 +4253,4 @@ Authors' Addresses
 
 
 
-Wilton, et al.          Expires 3 September 2026               [Page 76]
+Wilton, et al.          Expires 4 September 2026               [Page 76]

--- a/yang-packages/draft-ietf-netmod-yang-packages.xml
+++ b/yang-packages/draft-ietf-netmod-yang-packages.xml
@@ -263,8 +263,8 @@
 
       <section anchor="issues" title="Open Questions/Issues">
         <t>RFC Editor, please remove this section before publication.</t>
-        <t>All issues, along with the draft text, are currently being tracked at
-        https://github.com/rgwilton/YANG-Packages-Draft/issues/</t>
+	<t>All issues, along with the draft text, are currently being tracked at
+	https://github.com/netmod-wg/yang-ver-dt/issues/</t>
       </section>
     </section>
 


### PR DESCRIPTION
The temporary link in sec. 2.3 points to the old repository, confusingly; updating to the new one.