### PR TITLE
Add additionaly clarity based on Tony Li's comments:

### DIFF
--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -1049,9 +1049,9 @@ Internet-Draft                 YANG Semver                    April 2026
    versions in their revisions.  This is an update to the guidance
    provided in Section 4.8 of [RFC9907].  As IETF modules are not
    expected to require branching in their revision history, the
-   '_COMPAT' modifier SHOULD NOT be used in IETF published modules.  For
-   more detailed guidance on YANG Semver for IANA maintained YANG
-   modules and submodules, see [I-D.ietf-netmod-iana-yang-guidance].
+   '_COMPAT' modifier SHOULD NOT be used in IETF published modules.
+
+
 
 
 
@@ -1708,6 +1708,9 @@ Internet-Draft                 YANG Semver                    April 2026
    modules will not need to use the "_compatible" or "_non_compatible"
    modifiers with the "Z_COMPAT" version element.
 
+   See [I-D.ietf-netmod-iana-yang-guidance] for complete guidance on how
+   to handle versioning for IANA maintained YANG modules.
+
 13.  References
 
 13.1.  Normative References
@@ -1726,9 +1729,6 @@ Internet-Draft                 YANG Semver                    April 2026
               DOI 10.17487/RFC6020, October 2010,
               <https://www.rfc-editor.org/info/rfc6020>.
 
-   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
-              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
-              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
 
 
@@ -1737,6 +1737,10 @@ Clarke, et al.           Expires 15 October 2026               [Page 31]
 
 Internet-Draft                 YANG Semver                    April 2026
 
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
    [RFC7950]  Bjorklund, M., Ed., "The YANG 1.1 Data Modeling Language",
               RFC 7950, DOI 10.17487/RFC7950, August 2016,
@@ -1783,10 +1787,6 @@ Internet-Draft                 YANG Semver                    April 2026
               <https://datatracker.ietf.org/doc/html/draft-ietf-netmod-
               yang-packages-06>.
 
-   [I-D.ietf-netmod-yang-schema-comparison]
-              Andersson, P., Wilton, R., and M. Vaško, "YANG Schema
-              Comparison", Work in Progress, Internet-Draft, draft-ietf-
-
 
 
 Clarke, et al.           Expires 15 October 2026               [Page 32]
@@ -1794,6 +1794,9 @@ Clarke, et al.           Expires 15 October 2026               [Page 32]
 Internet-Draft                 YANG Semver                    April 2026
 
 
+   [I-D.ietf-netmod-yang-schema-comparison]
+              Andersson, P., Wilton, R., and M. Vaško, "YANG Schema
+              Comparison", Work in Progress, Internet-Draft, draft-ietf-
               netmod-yang-schema-comparison-06, 15 February 2026,
               <https://datatracker.ietf.org/doc/html/draft-ietf-netmod-
               yang-schema-comparison-06>.
@@ -1839,9 +1842,6 @@ Internet-Draft                 YANG Semver                    April 2026
               DOI 10.17487/RFC9000, May 2021,
               <https://www.rfc-editor.org/info/rfc9000>.
 
-   [openconfigsemver]
-              "Semantic Versioning for Openconfig Models",
-              <http://www.openconfig.net/docs/semver/>.
 
 
 
@@ -1849,6 +1849,10 @@ Clarke, et al.           Expires 15 October 2026               [Page 33]
 
 Internet-Draft                 YANG Semver                    April 2026
 
+
+   [openconfigsemver]
+              "Semantic Versioning for Openconfig Models",
+              <http://www.openconfig.net/docs/semver/>.
 
    [SemVer]   "Semantic Versioning 2.0.0 (text from June 19, 2020)",
               <https://github.com/semver/semver/
@@ -1894,10 +1898,6 @@ Appendix A.  Example IETF Module Development
          |
        0.5.0
 
-   At this point, the draft is standardized and becomes RFC12345 and the
-   YANG module version becomes 1.0.0.
-
-
 
 
 
@@ -1905,6 +1905,9 @@ Clarke, et al.           Expires 15 October 2026               [Page 34]
 
 Internet-Draft                 YANG Semver                    April 2026
 
+
+   At this point, the draft is standardized and becomes RFC12345 and the
+   YANG module version becomes 1.0.0.
 
    A time later, the module needs to be revised to add additional
    capabilities.  Development will be done in a backwards-compatible
@@ -1948,11 +1951,8 @@ Appendix B.  Examples of _COMPAT Modifier Use
    YANG Semver of a YANG module.  While module development is considered
    here, this is appliacable to any YANG artifact.
 
-   In the scenarios below, the X axis represents relative time (date &
-   time) that a module is being published.  Module versions to the right
-   are more recent than module versions to the left.  In scenario 1, for
-   example, the time ordered publishing of module versions is: 2.0.0,
-   2.1.0, 3.0.0, A, B.
+
+
 
 
 
@@ -1961,6 +1961,12 @@ Clarke, et al.           Expires 15 October 2026               [Page 35]
 
 Internet-Draft                 YANG Semver                    April 2026
 
+
+   In the scenarios below, the X axis represents relative time (date &
+   time) that a module is being published.  Module versions to the right
+   are more recent than module versions to the left.  In scenario 1, for
+   example, the time ordered publishing of module versions is: 2.0.0,
+   2.1.0, 3.0.0, A, B.
 
    It is also useful to consider the leftmost sequence (diagonal column)
    of versions (going mostly downwards and slightly right) as the "main
@@ -1997,6 +2003,21 @@ Internet-Draft                 YANG Semver                    April 2026
    recommended (likely to cause confusion since it does not have 3.0.0
    as an ancestor).
 
+
+
+
+
+
+
+
+
+
+
+Clarke, et al.           Expires 15 October 2026               [Page 36]
+
+Internet-Draft                 YANG Semver                    April 2026
+
+
            2.0.0
              \
               \
@@ -2009,14 +2030,6 @@ Internet-Draft                 YANG Semver                    April 2026
                  2.2.1-------------Q
 
                             Figure 7: Scenario 2
-
-
-
-
-Clarke, et al.           Expires 15 October 2026               [Page 36]
-
-Internet-Draft                 YANG Semver                    April 2026
-
 
    For each revision N, P and Q, the following are possible YANG Semver
    versions when the revision is backwards comptible (BC) or non
@@ -2053,6 +2066,14 @@ Authors' Addresses
 
    Robert Wilton (editor)
    Cisco Systems, Inc.
+
+
+
+Clarke, et al.           Expires 15 October 2026               [Page 37]
+
+Internet-Draft                 YANG Semver                    April 2026
+
+
    Email: rwilton@cisco.com
 
 
@@ -2066,14 +2087,6 @@ Authors' Addresses
    1117 Budapest
    Magyar Tudosok Korutja
    Hungary
-
-
-
-Clarke, et al.           Expires 15 October 2026               [Page 37]
-
-Internet-Draft                 YANG Semver                    April 2026
-
-
    Phone: +36-70-330-7909
    Email: balazs.lengyel@ericsson.com
 
@@ -2086,19 +2099,6 @@ Internet-Draft                 YANG Semver                    April 2026
    Benoit Claise
    Everything OPS
    Email: benoit@everything-ops.net
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -4,16 +4,16 @@
 
 Network Working Group                                     J. Clarke, Ed.
 Internet-Draft                                            R. Wilton, Ed.
-Updates: 8407, 8525, 7950 (if approved)              Cisco Systems, Inc.
+Updates: 9907, 8525, 7950 (if approved)              Cisco Systems, Inc.
 Intended status: Standards Track                               R. Rahman
-Expires: 25 September 2026                                       Equinix
+Expires: 2 October 2026                                          Equinix
                                                               B. Lengyel
                                                                 Ericsson
                                                                J. Sterne
                                                                    Nokia
                                                                B. Claise
                                                           Everything OPS
-                                                           24 March 2026
+                                                           31 March 2026
 
 
                         YANG Semantic Versioning
@@ -27,7 +27,7 @@ Abstract
    document defines a YANG extension for controlling module imports
    based on these modified semantic versioning rules.
 
-   This document updates RFCs 7950, 8407bis, and 8525.
+   This document updates RFCs 7950, 9907, and 8525.
 
 Status of This Memo
 
@@ -44,7 +44,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 25 September 2026.
+   This Internet-Draft will expire on 2 October 2026.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Clarke, et al.          Expires 25 September 2026               [Page 1]
+Clarke, et al.           Expires 2 October 2026                 [Page 1]
 
 Internet-Draft                 YANG Semver                    March 2026
 
@@ -71,45 +71,45 @@ Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
      1.1.  Updates to Other RFCs . . . . . . . . . . . . . . . . . .   3
-     1.2.  Editorial Note (To be removed by RFC Editor)  . . . . . .   3
+     1.2.  Editorial Note (To be removed by RFC Editor)  . . . . . .   4
    2.  Examples of How Versioning Is Applied To YANG Module
            Revisions . . . . . . . . . . . . . . . . . . . . . . . .   4
-   3.  Terminology and Conventions . . . . . . . . . . . . . . . . .   4
+   3.  Terminology and Conventions . . . . . . . . . . . . . . . . .   5
    4.  YANG Semantic Versioning  . . . . . . . . . . . . . . . . . .   5
      4.1.  Relationship Between SemVer and YANG Semver . . . . . . .   5
-     4.2.  YANG Semantic Version Extension . . . . . . . . . . . . .   5
-     4.3.  YANG Semver Pattern . . . . . . . . . . . . . . . . . . .   5
-     4.4.  Semantic Versioning Scheme for YANG Artifacts . . . . . .   6
-       4.4.1.  YANG Semver with submodules . . . . . . . . . . . . .   8
-       4.4.2.  Examples for YANG semantic versions . . . . . . . . .   9
+     4.2.  YANG Semantic Version Extension . . . . . . . . . . . . .   6
+     4.3.  YANG Semver Pattern . . . . . . . . . . . . . . . . . . .   6
+     4.4.  Semantic Versioning Scheme for YANG Artifacts . . . . . .   7
+       4.4.1.  YANG Semver with submodules . . . . . . . . . . . . .   9
+       4.4.2.  Examples for YANG semantic versions . . . . . . . . .  10
        4.4.3.  Branching Limitations with YANG Semver  . . . . . . .  11
-     4.5.  YANG Semantic Version Update Rules  . . . . . . . . . . .  11
-     4.6.  Examples of the YANG Semver Version Identifier  . . . . .  13
-       4.6.1.  Example Module Using YANG Semver  . . . . . . . . . .  13
-       4.6.2.  Example of Package Using YANG Semver  . . . . . . . .  15
+     4.5.  YANG Semantic Version Update Rules  . . . . . . . . . . .  12
+     4.6.  Examples of the YANG Semver Version Identifier  . . . . .  14
+       4.6.1.  Example Module Using YANG Semver  . . . . . . . . . .  14
+       4.6.2.  Example of Package Using YANG Semver  . . . . . . . .  16
    5.  Import Module by YANG Semantic Version  . . . . . . . . . . .  16
-     5.1.  The recommended-min-version Extension . . . . . . . . . .  16
+     5.1.  The recommended-min-version Extension . . . . . . . . . .  17
      5.2.  Import by YANG Semantic Version Rules . . . . . . . . . .  17
    6.  Guidelines for Using YANG Semver During Module Development  .  18
      6.1.  YANG Semver in IETF Modules . . . . . . . . . . . . . . .  19
-       6.1.1.  YANG Semver in New IETF Modules . . . . . . . . . . .  19
-       6.1.2.  YANG Semver when updating IETF Modules  . . . . . . .  19
+       6.1.1.  YANG Semver in New IETF Modules . . . . . . . . . . .  20
+       6.1.2.  YANG Semver when updating IETF Modules  . . . . . . .  20
        6.1.3.  YANG Semver when there are multiple parallel competing
                IETF drafts . . . . . . . . . . . . . . . . . . . . .  20
-   7.  Updates to ietf-yang-library  . . . . . . . . . . . . . . . .  21
-     7.1.  YANG library versioning augmentations . . . . . . . . . .  21
+   7.  Updates to ietf-yang-library  . . . . . . . . . . . . . . . .  22
+     7.1.  YANG library versioning augmentations . . . . . . . . . .  22
        7.1.1.  Advertising version . . . . . . . . . . . . . . . . .  22
    8.  YANG Modules  . . . . . . . . . . . . . . . . . . . . . . . .  22
    9.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  28
    10. Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  28
-   11. Security Considerations . . . . . . . . . . . . . . . . . . .  28
+   11. Security Considerations . . . . . . . . . . . . . . . . . . .  29
    12. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  29
      12.1.  YANG Module Registrations  . . . . . . . . . . . . . . .  29
 
 
 
 
-Clarke, et al.          Expires 25 September 2026               [Page 2]
+Clarke, et al.           Expires 2 October 2026                 [Page 2]
 
 Internet-Draft                 YANG Semver                    March 2026
 
@@ -119,7 +119,7 @@ Internet-Draft                 YANG Semver                    March 2026
    13. References  . . . . . . . . . . . . . . . . . . . . . . . . .  31
      13.1.  Normative References . . . . . . . . . . . . . . . . . .  31
      13.2.  Informative References . . . . . . . . . . . . . . . . .  32
-   Appendix A.  Example IETF Module Development  . . . . . . . . . .  33
+   Appendix A.  Example IETF Module Development  . . . . . . . . . .  34
    Appendix B.  Examples of _COMPAT Modifier Use . . . . . . . . . .  35
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  37
 
@@ -142,7 +142,9 @@ Internet-Draft                 YANG Semver                    March 2026
    herein represent the recommended approach to apply versioning to IETF
    YANG artifacts.  This document defines augmentations to ietf-yang-
    library to reflect the version of YANG modules within the module-set
-   data.
+   data.  YANG Semver extends SemVer with an optional '_COMPAT' suffix
+   to support limited branching within YANG artifact revision histories,
+   as described in Section 4.3 and Section 4.4.3.
 
    Note that a specific revision of the SemVer 2.0.0 specification is
    referenced here (from June 19, 2020) to provide an immutable version.
@@ -154,25 +156,26 @@ Internet-Draft                 YANG Semver                    March 2026
    This document updates [RFC7950] to clarify how ambiguous module
    imports are resolved (Section 5).  It updates [RFC8525] by adding a
    version leaf to modules and submodules (Section 7).  It updates
-   [I-D.ietf-netmod-rfc8407bis] to clarify how version statements are to
-   be added to modules and submodules (Section 6).
+   [RFC9907] to clarify how version statements are to be added to
+   modules and submodules (Section 6).
+
+
+
+
+
+
+
+Clarke, et al.           Expires 2 October 2026                 [Page 3]
+
+Internet-Draft                 YANG Semver                    March 2026
+
 
 1.2.  Editorial Note (To be removed by RFC Editor)
 
       Note to the RFC Editor: This section is to be removed prior to
       publication.
 
-
-
-
-Clarke, et al.          Expires 25 September 2026               [Page 3]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
-   This document updates [I-D.ietf-netmod-rfc8407bis].  The header
-   metadata for this document should be updated to the new RFC number
-   when [I-D.ietf-netmod-rfc8407bis] is published.
+   This document updates [RFC9907].
 
 2.  Examples of How Versioning Is Applied To YANG Module Revisions
 
@@ -199,6 +202,36 @@ Internet-Draft                 YANG Semver                    March 2026
    The tree diagram above illustrates how an example module's revision
    history might evolve, over time.
 
+   For IETF modules, branching does not occur, resulting in a simpler
+   linear revision history.  The following diagram illustrates a typical
+   IETF module revision history:
+
+   Example IETF YANG module with linear revision history.
+
+          Module revision date      Example version identifier
+            2019-01-01                 <- 1.0.0
+                |
+            2019-07-01                 <- 1.1.0
+                |
+            2020-03-01                 <- 2.0.0
+                |
+            2021-02-15                 <- 2.1.0
+                |
+            2022-09-30                 <- 3.0.0
+
+
+
+Clarke, et al.           Expires 2 October 2026                 [Page 4]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
+                                  Figure 2
+
+   Note that when no branching occurs, YANG Semver identifiers are
+   equivalent to standard SemVer version numbers and the '_COMPAT'
+   modifier is not needed.
+
 3.  Terminology and Conventions
 
    The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
@@ -217,14 +250,6 @@ Internet-Draft                 YANG Semver                    March 2026
       [SemVer].  This specific camel-case notation is the one used by
       the SemVer 2.0.0 website and used within this document to
       distinguish between SemVer 2.0.0 and YANG Semver.
-
-
-
-
-Clarke, et al.          Expires 25 September 2026               [Page 4]
-
-Internet-Draft                 YANG Semver                    March 2026
-
 
    *  YANG Semver: A version identifier that is consistent with the
       extended set of semantic versioning rules, based on [SemVer],
@@ -245,7 +270,20 @@ Internet-Draft                 YANG Semver                    March 2026
    superset of the SemVer rules, and allows for limited branching within
    YANG artifacts.  If no branching occurs within a YANG artifact (i.e.,
    you do not use the compatibility modifiers described below), the YANG
-   Semver version label will appear as a SemVer version number.
+   Semver version label will appear as a SemVer version number.  Note
+   that standard SemVer does not support branching and assumes a single
+   linear progression of releases.  The optional '_COMPAT' modifier is
+   unique to YANG Semver and is introduced to support the limited
+
+
+
+Clarke, et al.           Expires 2 October 2026                 [Page 5]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
+   branching that may be needed for certain YANG artifact revision
+   histories.
 
 4.2.  YANG Semantic Version Extension
 
@@ -275,13 +313,6 @@ Internet-Draft                 YANG Semver                    March 2026
    *  COMPAT, if specified, MUST be either the literal string
       "compatible" or the literal string "non_compatible".
 
-
-
-Clarke, et al.          Expires 25 September 2026               [Page 5]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
    Additionally, [SemVer] defines two specific types of metadata that
    may be appended to a semantic version string.  Pre-release metadata
    MAY be appended to a YANG Semver string after a trailing '-'
@@ -299,6 +330,13 @@ Internet-Draft                 YANG Semver                    March 2026
    extension to apply a YANG Semver identifier to a YANG artifact as
    well as a typedef that formally specifies the syntax of the YANG
    Semver.
+
+
+
+Clarke, et al.           Expires 2 October 2026                 [Page 6]
+
+Internet-Draft                 YANG Semver                    March 2026
+
 
 4.4.  Semantic Versioning Scheme for YANG Artifacts
 
@@ -329,15 +367,6 @@ Internet-Draft                 YANG Semver                    March 2026
       semantic versioning scheme are exactly the same as those defined
       by the [SemVer] versioning scheme.
 
-
-
-
-
-Clarke, et al.          Expires 25 September 2026               [Page 6]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
    Every YANG module and submodule versioned using the YANG semantic
    versioning scheme specifies the module's or submodule's semantic
    version as the argument to the 'ysv:version' statement.
@@ -355,6 +384,15 @@ Internet-Draft                 YANG Semver                    March 2026
 
    As stated above, the YANG semantic version is expressed as a string
    of the form: 'X.Y.Z_COMPAT'.
+
+
+
+
+
+Clarke, et al.           Expires 2 October 2026                 [Page 7]
+
+Internet-Draft                 YANG Semver                    March 2026
+
 
    *  'X' is the MAJOR version.  Changes in the MAJOR version number
       indicate changes that are non-backwards-compatible (Section 3.1.1
@@ -387,13 +425,6 @@ Internet-Draft                 YANG Semver                    March 2026
       same MAJOR and MINOR version numbers, but lower PATCH version
       number, depending on what form modifier '_COMPAT' takes:
 
-
-
-Clarke, et al.          Expires 25 September 2026               [Page 7]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
       -  If the modifier string is absent, the change represents an
          editorial change.
 
@@ -411,6 +442,14 @@ Internet-Draft                 YANG Semver                    March 2026
    module versions in that branch (i.e., those with the same X.Y version
    digits) will also have a modifier.  The modifier can change from
    "_compatible" to "_non_compatible" in a subsequent version, but the
+
+
+
+Clarke, et al.           Expires 2 October 2026                 [Page 8]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
    modifier MUST NOT change from "_non_compatible" to "_compatible" and
    MUST NOT be removed.  The persistence of the "_non_compatible"
    modifier ensures that comparisons of versions do not give the false
@@ -440,16 +479,6 @@ Internet-Draft                 YANG Semver                    March 2026
    submodule has changed, then the version of the including module MUST
    also be updated.
 
-
-
-
-
-
-Clarke, et al.          Expires 25 September 2026               [Page 8]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
    The rules for determining the version change of a submodule are the
    same as those defined in Section 4.3 and Section 4.4 as applied to
    YANG modules, except they only apply to the part of the module schema
@@ -469,6 +498,13 @@ Internet-Draft                 YANG Semver                    March 2026
    3.  The submodule with the schema definitions added has backwards-
        compatible changes and must receive a new version number with a
        MINOR component modification.
+
+
+
+Clarke, et al.           Expires 2 October 2026                 [Page 9]
+
+Internet-Draft                 YANG Semver                    March 2026
+
 
    Note that the meaning of a submodule may change drastically despite
    having no changes in content or revision due to changes in other
@@ -498,14 +534,6 @@ Internet-Draft                 YANG Semver                    March 2026
               |         1.4.0
             3.1.0
 
-
-
-
-Clarke, et al.          Expires 25 September 2026               [Page 9]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
    The tree diagram above illustrates how the version history might
    evolve for an example module.  The tree diagram only shows the
    branching relationships between the versions.  It does not describe
@@ -524,6 +552,15 @@ Internet-Draft                 YANG Semver                    March 2026
       1.1.0 - added new functionality, leaf "foo" (BC)
 
       1.2.0 - added new functionality, leaf "baz" (BC)
+
+
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 10]
+
+Internet-Draft                 YANG Semver                    March 2026
+
 
       2.0.0 - change existing model for performance reasons, e.g. re-key
       list (NBC)
@@ -553,15 +590,6 @@ Internet-Draft                 YANG Semver                    March 2026
       1.2.2_non_compatible - backport "wibble".  This is a BC change but
       "non_compatible" modifier is sticky.  (BC)
 
-
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 10]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
 4.4.3.  Branching Limitations with YANG Semver
 
    YANG artifacts that use the YANG Semver version scheme MUST ensure
@@ -580,6 +608,15 @@ Internet-Draft                 YANG Semver                    March 2026
    3.20.0, one would assume that 3.20.0 is backwards compatible with
    3.6.0.  But in the illegal example above, 3.20.0 is not backwards
    compatible with 3.6.0 since 3.20.0 does not contain the leaf foo.
+
+
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 11]
+
+Internet-Draft                 YANG Semver                    March 2026
+
 
    Branching limitations should be carefully considered when doing
    software development.  It is recommended to avoid only incrementing
@@ -608,16 +645,6 @@ Internet-Draft                 YANG Semver                    March 2026
        then the next version number depends on the format of the current
        version number:
 
-
-
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 11]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
        i    "X.Y.Z" - the artifact version SHOULD be updated to
             "X.Y+1.0", unless that version has already been used for
             this artifact but with different content, when the artifact
@@ -638,6 +665,14 @@ Internet-Draft                 YANG Semver                    March 2026
 
        ii   "X.Y.Z_compatible" - the artifact version SHOULD be updated
             to "X.Y.Z+1_compatible".
+
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 12]
+
+Internet-Draft                 YANG Semver                    March 2026
+
 
        iii  "X.Y.Z_non_compatible" - the artifact version SHOULD be
             updated to "X.Y.Z+1_non_compatible".
@@ -665,15 +700,6 @@ Internet-Draft                 YANG Semver                    March 2026
        have occurred, or an artifact could be given a new MINOR version
        number (i.e., X.Y+1.0) even if the changes were only editorial.
 
-
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 12]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
    2.  An artifact author MAY skip versions.  For example, a vendor
        might have released 1.0.0 of a module for general availability.
        Then, during subsequent development, used 1.1.0 and 1.2.0 for
@@ -688,6 +714,21 @@ Internet-Draft                 YANG Semver                    March 2026
    [I-D.ietf-netmod-yang-schema-comparison], also plays an important
    role for comparing YANG artifacts and calculating the likely impact
    from changes.
+
+
+
+
+
+
+
+
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 13]
+
+Internet-Draft                 YANG Semver                    March 2026
+
 
    [I-D.ietf-netmod-yang-module-versioning] defines the "rev:non-
    backwards-compatible" extension statement to indicate where non-
@@ -722,14 +763,6 @@ Internet-Draft                 YANG Semver                    March 2026
          ysv:version 1.2.2_non_compatible;
        }
 
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 13]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
        revision 2017-07-30 {
          description "Rename 'baz' to 'bar'";
          ysv:version 1.2.1_non_compatible;
@@ -745,6 +778,13 @@ Internet-Draft                 YANG Semver                    March 2026
          description "Add new functionality, leaf 'foo'";
          ysv:version 1.1.0;
        }
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 14]
+
+Internet-Draft                 YANG Semver                    March 2026
+
 
        revision 2017-02-07 {
          description "First release version.";
@@ -778,14 +818,6 @@ Internet-Draft                 YANG Semver                    March 2026
              example-versioned-module.";
          leaf qux {
            type string;
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 14]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
            description
              "The qux instance of the device.";
          }
@@ -802,6 +834,14 @@ Internet-Draft                 YANG Semver                    March 2026
          }
          leaf wibble {
            type boolean;
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 15]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
            description
              "Does it wibble (true) or wobble (false)?";
          }
@@ -813,34 +853,6 @@ Internet-Draft                 YANG Semver                    March 2026
    Below is an example YANG package that uses the YANG Semver version
    identifier based on the rules defined in this document.  Note: '\'
    line wrapping per [RFC8792].
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 15]
-
-Internet-Draft                 YANG Semver                    March 2026
-
 
    {
      "ietf-yang-instance-data:instance-data-set": {
@@ -865,7 +877,7 @@ Internet-Draft                 YANG Semver                    March 2026
      }
    }
 
-                                  Figure 2
+                                  Figure 3
 
 5.  Import Module by YANG Semantic Version
 
@@ -875,6 +887,16 @@ Internet-Draft                 YANG Semver                    March 2026
    the specified revision date in the import.  This section defines a
    similar extension for controlling import by YANG semantic version, as
    well as the rules for how imports are resolved.
+
+
+
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 16]
+
+Internet-Draft                 YANG Semver                    March 2026
+
 
 5.1.  The recommended-min-version Extension
 
@@ -888,15 +910,6 @@ Internet-Draft                 YANG Semver                    March 2026
    below.  At most one instance of recommended-min-version MAY be used.
    Removing, adding or changing the recommended-min-version statement is
    considered a backwards compatible change.  An example use is:
-
-
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 16]
-
-Internet-Draft                 YANG Semver                    March 2026
-
 
            import example-module {
                ysv:recommended-min-version 3.0.0;
@@ -933,6 +946,14 @@ Internet-Draft                 YANG Semver                    March 2026
 
       4.1.2 (by condition 4 above)
 
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 17]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
       3.1.1_compatible (by condition 2 above, noting that modifiers are
       ignored)
 
@@ -947,19 +968,11 @@ Internet-Draft                 YANG Semver                    March 2026
    conditions above, that YANG compiler should emit a warning, and then
    continue to resolve the import based on established [RFC7950] rules.
 
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 17]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
 6.  Guidelines for Using YANG Semver During Module Development
 
    This section and the IETF-specific sub-section below provide YANG
    Semver-specific guidelines to consider when developing new YANG
-   modules.  As such this section updates Section 4.8 of
-   [I-D.ietf-netmod-rfc8407bis].
+   modules.  As such this section updates Section 4.8 of [RFC9907].
 
    All modules and submodules being developed or updated that use the
    YANG Semver versioning scheme MUST have unique YANG Semver version
@@ -990,6 +1003,13 @@ Internet-Draft                 YANG Semver                    March 2026
 
       1.0.0-beta.42
 
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 18]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
       1.0.0-202007.rc
 
       1.0.0-20250106
@@ -1002,14 +1022,6 @@ Internet-Draft                 YANG Semver                    March 2026
    or submodule which has a current version of 1.0.0 is being modified
    with the intent to make non-backwards-compatible changes, the first
    development MAJOR version component should be 2 with some pre-release
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 18]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
    notation such as -alpha.1, making the version 2.0.0-alpha.1.  It may
    be prudent to include the year or year and month development began
    (e.g., 2.0.0-201907-alpha.1) in order to guarantee uniqueness.  As a
@@ -1035,7 +1047,24 @@ Internet-Draft                 YANG Semver                    March 2026
 
    All published IETF modules and submodules MUST use YANG semantic
    versions in their revisions.  This is an update to the guidance
-   provided in Section 4.8 of [I-D.ietf-netmod-rfc8407bis].
+   provided in Section 4.8 of [RFC9907].  As IETF modules are not
+   expected to require branching in their revision history, the
+   '_COMPAT' modifier SHOULD NOT be used in IETF published modules.  For
+   more detailed guidance on YANG Semver for IANA maintained YANG
+   modules and submodules, see [I-D.ietf-netmod-iana-yang-guidance].
+
+
+
+
+
+
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 19]
+
+Internet-Draft                 YANG Semver                    March 2026
+
 
 6.1.1.  YANG Semver in New IETF Modules
 
@@ -1058,13 +1087,6 @@ Internet-Draft                 YANG Semver                    March 2026
    REVISION is the draft revision number (e.g., 1.1.0-01, 1.1.0-02).
    This notation is described in detail, including the special
    considerations for parallel competing drafts, in Section 6.1.3.
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 19]
-
-Internet-Draft                 YANG Semver                    March 2026
-
 
 6.1.2.1.  Guidelines for IETF Modules Previously Published without YANG
           Semvers
@@ -1092,6 +1114,14 @@ Internet-Draft                 YANG Semver                    March 2026
    The following recommendations apply to the 2nd, 3rd, etc. parallel
    drafts that develop a module or submodule with the same name.  The
    first draft published can simply use the guidelines above without any
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 20]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
    extra metadata described below.  The YANG Semver in subsequent drafts
    SHOULD include the full document name as a pre-release version
    identifier, including the current document revision.  For example, if
@@ -1114,13 +1144,6 @@ Internet-Draft                 YANG Semver                    March 2026
    1.  Using unique module names (i.e., module names with unique
        prefixes such as the author's name, e.g. johnsmith-
        interfaces.yang), or
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 20]
-
-Internet-Draft                 YANG Semver                    March 2026
-
 
    2.  Using unique strings within the YANG Semver pre-release metadata
        (e.g. 2.0.0-johnsmith-02).
@@ -1146,6 +1169,15 @@ Internet-Draft                 YANG Semver                    March 2026
 
    See Appendix A for a detailed example of IETF pre-release versions.
 
+
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 21]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
 7.  Updates to ietf-yang-library
 
    This document updates YANG 1.1 [RFC7950] and YANG library [RFC8525]
@@ -1158,25 +1190,6 @@ Internet-Draft                 YANG Semver                    March 2026
 
    The "ietf-yang-library-semver" YANG module has the following
    structure (using the notation defined in [RFC8340]):
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 21]
-
-Internet-Draft                 YANG Semver                    March 2026
-
 
    module: ietf-yang-library-semver
 
@@ -1192,7 +1205,7 @@ Internet-Draft                 YANG Semver                    March 2026
                /yanglib:import-only-module/yanglib:submodule:
        +--ro version?   ysv:version
 
-                                  Figure 3
+                                  Figure 4
 
 7.1.1.  Advertising version
 
@@ -1213,6 +1226,14 @@ Internet-Draft                 YANG Semver                    March 2026
      prefix ysv;
 
      organization
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 22]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
        "IETF NETMOD (Network Modeling) Working Group";
      contact
        "WG Web:   <http://datatracker.ietf.org/wg/netmod/>
@@ -1226,14 +1247,6 @@ Internet-Draft                 YANG Semver                    March 2026
                   <mailto:reshad@yahoo.com>
         Author:   Balazs Lengyel
                   <mailto:balazs.lengyel@ericsson.com>
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 22]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
         Author:   Jason Sterne
                   <mailto:jason.sterne@nokia.com>
         Author:   Benoit Claise
@@ -1269,6 +1282,14 @@ Internet-Draft                 YANG Semver                    March 2026
 
      revision 2026-03-03 {
        ysv:version "0.25.0";
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 23]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
        description
          "Initial revision";
        reference
@@ -1282,14 +1303,6 @@ Internet-Draft                 YANG Semver                    March 2026
      extension version {
        argument yang-semantic-version;
        description
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 23]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
          "The version extension is used to assign a version number
           to a module or submodule revision.
 
@@ -1325,6 +1338,14 @@ Internet-Draft                 YANG Semver                    March 2026
 
           The statement MUST only be a substatement of the import
           statement.  Zero or one 'recommended-min-version'
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 24]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
           statements per parent statement are allowed.  No
           substatements for this extension have been
           standardized.
@@ -1338,14 +1359,6 @@ Internet-Draft                 YANG Semver                    March 2026
           * Has the same MAJOR and MINOR version numbers and a
             greater PATCH number.
           * Has the same MAJOR version number and greater MINOR number.
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 24]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
             In this case the PATCH number is ignored.
           * Has a greater MAJOR version number.  In this case MINOR
             and PATCH numbers are ignored.
@@ -1380,6 +1393,15 @@ Internet-Draft                 YANG Semver                    March 2026
    This YANG module contains the augmentations to the ietf-yang-library
    [RFC8525].
 
+
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 25]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
    <CODE BEGINS> file "ietf-yang-library-semver@2025-09-29.yang"
    module ietf-yang-library-semver {
      yang-version 1.1;
@@ -1394,14 +1416,6 @@ Internet-Draft                 YANG Semver                    March 2026
      import ietf-yang-library {
        prefix yanglib;
        reference
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 25]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
          "RFC 8525: YANG Library";
      }
 
@@ -1437,6 +1451,13 @@ Internet-Draft                 YANG Semver                    March 2026
         Relating to IETF Documents
         (http://trustee.ietf.org/license-info).
 
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 26]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
         This version of this YANG module is part of RFC XXXX; see
         the RFC itself for full legal notices.
 
@@ -1450,14 +1471,6 @@ Internet-Draft                 YANG Semver                    March 2026
      // and remove this note.
      // RFC Ed.: replace XXXX (including in the imports above) with
      // actual RFC number and remove this note.
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 26]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
      // RFC Ed.: please replace ysv:version with 1.0.0 and
      // remove this note.
 
@@ -1493,6 +1506,14 @@ Internet-Draft                 YANG Semver                    March 2026
        uses module-version;
      }
 
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 27]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
      augment "/yanglib:yang-library/yanglib:module-set/yanglib:module/"
            + "yanglib:submodule" {
        description
@@ -1506,13 +1527,6 @@ Internet-Draft                 YANG Semver                    March 2026
          "Add a version to module information";
        uses module-version;
      }
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 27]
-
-Internet-Draft                 YANG Semver                    March 2026
-
 
      augment "/yanglib:yang-library/yanglib:module-set/"
            + "yanglib:import-only-module/yanglib:submodule" {
@@ -1534,7 +1548,7 @@ Internet-Draft                 YANG Semver                    March 2026
      jlindbla@cisco.com
 
 
-                                  Figure 4
+                                  Figure 5
 
 10.  Acknowledgments
 
@@ -1545,6 +1559,16 @@ Internet-Draft                 YANG Semver                    March 2026
    Clarke, Juergen Schoenwaelder, Mahesh Jethanandani, Michael
    (Wangzitao), Per Andersson, Qin Wu, Reshad Rahman, Tom Hill, and Rob
    Wilton.
+
+
+
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 28]
+
+Internet-Draft                 YANG Semver                    March 2026
+
 
    The initial revision of this document was refactored and built upon
    [I-D.clacla-netmod-yang-model-update].  We would like to thank Kevin
@@ -1561,14 +1585,7 @@ Internet-Draft                 YANG Semver                    March 2026
 11.  Security Considerations
 
    This section is modeled after the template described in Section 3.7
-   of [I-D.ietf-netmod-rfc8407bis].
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 28]
-
-Internet-Draft                 YANG Semver                    March 2026
-
+   of [RFC9907].
 
    The "ietf-yang-semver" and "ietf-yang-library-semver" YANG modules
    define data models that are designed to be accessed via YANG-based
@@ -1602,6 +1619,13 @@ Internet-Draft                 YANG Semver                    March 2026
 
       XML: N/A, the requested URI is an XML namespace.
 
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 29]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
       URI: urn:ietf:params:xml:ns:yang:ietf-yang-library-semver
 
       Registrant Contact: The IESG.
@@ -1617,14 +1641,6 @@ Internet-Draft                 YANG Semver                    March 2026
       Name: ietf-yang-semver
 
       XML Namespace: urn:ietf:params:xml:ns:yang:ietf-yang-semver
-
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 29]
-
-Internet-Draft                 YANG Semver                    March 2026
-
 
       Prefix: ysv
 
@@ -1656,6 +1672,16 @@ Internet-Draft                 YANG Semver                    March 2026
    YANG modules and submodules, e.g., iana-if-types.yang [IfTypeYang]
    and iana-routing-types.yang [RoutingTypesYang].
 
+
+
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 30]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
    In addition to following the rules specified in the IANA
    Considerations section of [I-D.ietf-netmod-yang-module-versioning],
    IANA maintained YANG modules and submodules MUST also include a YANG
@@ -1671,16 +1697,6 @@ Internet-Draft                 YANG Semver                    March 2026
    version "1.0.0" for the initial published revision, and then
    incrementing according to the YANG Semver rules specified in
    Section 4.5.
-
-
-
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 30]
-
-Internet-Draft                 YANG Semver                    March 2026
-
 
    Most changes to IANA maintained YANG modules and submodules are
    expected to be backwards-compatible changes and classified as MINOR
@@ -1714,6 +1730,14 @@ Internet-Draft                 YANG Semver                    March 2026
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 31]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
    [RFC7950]  Bjorklund, M., Ed., "The YANG 1.1 Data Modeling Language",
               RFC 7950, DOI 10.17487/RFC7950, August 2016,
               <https://www.rfc-editor.org/info/rfc7950>.
@@ -1731,20 +1755,10 @@ Internet-Draft                 YANG Semver                    March 2026
               <https://datatracker.ietf.org/doc/html/draft-ietf-netmod-
               yang-module-versioning-15>.
 
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 31]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
-   [I-D.ietf-netmod-rfc8407bis]
-              Bierman, A., Boucadair, M., and Q. Wu, "Guidelines for
-              Authors and Reviewers of Documents Containing YANG Data
-              Models", Work in Progress, Internet-Draft, draft-ietf-
-              netmod-rfc8407bis-28, 5 June 2025,
-              <https://datatracker.ietf.org/doc/html/draft-ietf-netmod-
-              rfc8407bis-28>.
+   [RFC9907]  Bierman, A., Boucadair, M., Ed., and Q. Wu, "Guidelines
+              for Authors and Reviewers of Documents Containing YANG
+              Data Models", BCP 216, RFC 9907, DOI 10.17487/RFC9907,
+              March 2026, <https://www.rfc-editor.org/info/rfc9907>.
 
 13.2.  Informative References
 
@@ -1754,6 +1768,13 @@ Internet-Draft                 YANG Semver                    March 2026
               Draft, draft-clacla-netmod-yang-model-update-06, 2 July
               2018, <https://datatracker.ietf.org/doc/html/draft-clacla-
               netmod-yang-model-update-06>.
+
+   [I-D.ietf-netmod-iana-yang-guidance]
+              Wilton, R., "Guidance for Managing YANG Modules in RFCs
+              and IANA Registries", Work in Progress, Internet-Draft,
+              draft-ietf-netmod-iana-yang-guidance-01, 17 March 2026,
+              <https://datatracker.ietf.org/doc/html/draft-ietf-netmod-
+              iana-yang-guidance-01>.
 
    [I-D.ietf-netmod-yang-packages]
               Wilton, R., Rahman, R., Clarke, J., and J. Sterne, "YANG
@@ -1765,6 +1786,14 @@ Internet-Draft                 YANG Semver                    March 2026
    [I-D.ietf-netmod-yang-schema-comparison]
               Andersson, P., Wilton, R., and M. Vaško, "YANG Schema
               Comparison", Work in Progress, Internet-Draft, draft-ietf-
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 32]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
               netmod-yang-schema-comparison-05, 20 October 2025,
               <https://datatracker.ietf.org/doc/html/draft-ietf-netmod-
               yang-schema-comparison-05>.
@@ -1786,13 +1815,6 @@ Internet-Draft                 YANG Semver                    March 2026
               and A. Bierman, Ed., "Network Configuration Protocol
               (NETCONF)", RFC 6241, DOI 10.17487/RFC6241, June 2011,
               <https://www.rfc-editor.org/info/rfc6241>.
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 32]
-
-Internet-Draft                 YANG Semver                    March 2026
-
 
    [RFC8040]  Bierman, A., Bjorklund, M., and K. Watsen, "RESTCONF
               Protocol", RFC 8040, DOI 10.17487/RFC8040, January 2017,
@@ -1821,6 +1843,13 @@ Internet-Draft                 YANG Semver                    March 2026
               "Semantic Versioning for Openconfig Models",
               <http://www.openconfig.net/docs/semver/>.
 
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 33]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
    [SemVer]   "Semantic Versioning 2.0.0 (text from June 19, 2020)",
               <https://github.com/semver/semver/
               blob/8b2e8eec394948632957639dfa99fc7ec6286911/semver.md>.
@@ -1842,13 +1871,6 @@ Appendix A.  Example IETF Module Development
    individual Internet Draft, draft-jdoe-netmod-example-module.  The
    following represents the initial version tree (i.e., value of
    ysv:version) of the module as it's being initially developed.
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 33]
-
-Internet-Draft                 YANG Semver                    March 2026
-
 
    Version lineage for initial module development:
 
@@ -1875,6 +1897,15 @@ Internet-Draft                 YANG Semver                    March 2026
    At this point, the draft is standardized and becomes RFC12345 and the
    YANG module version becomes 1.0.0.
 
+
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 34]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
    A time later, the module needs to be revised to add additional
    capabilities.  Development will be done in a backwards-compatible
    way.  Two new individual drafts are proposed to go about adding the
@@ -1893,18 +1924,6 @@ Internet-Draft                 YANG Semver                    March 2026
          1.1.0-draft-asmith-netmod-exmod-changes-00
            |
          1.1.0-draft-asmith-netmod-exmod-changes-01
-
-
-
-
-
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 34]
-
-Internet-Draft                 YANG Semver                    March 2026
-
 
    At this point, the WG decides to merge some aspects of both and adopt
    the work in asmith's draft as draft-ietf-netmod-exmod-changes.  Since
@@ -1935,6 +1954,14 @@ Appendix B.  Examples of _COMPAT Modifier Use
    example, the time ordered publishing of module versions is: 2.0.0,
    2.1.0, 3.0.0, A, B.
 
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 35]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
    It is also useful to consider the leftmost sequence (diagonal column)
    of versions (going mostly downwards and slightly right) as the "main
    branch" in a software development branching scheme, and the sequence
@@ -1948,20 +1975,6 @@ Appendix B.  Examples of _COMPAT Modifier Use
    standard bodies (which tend to be linear and only update the head of
    the single branch).
 
-
-
-
-
-
-
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 35]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
            2.0.0-----A
              \
               \
@@ -1970,7 +1983,7 @@ Internet-Draft                 YANG Semver                    March 2026
                 \
                3.0.0
 
-                            Figure 5: Scenario 1
+                            Figure 6: Scenario 1
 
    For each revision A and B, the following are possible YANG Semver
    versions when the revision is backwards comptible (BC) or non
@@ -1995,7 +2008,15 @@ Internet-Draft                 YANG Semver                    March 2026
                   \
                  2.2.1-------------Q
 
-                            Figure 6: Scenario 2
+                            Figure 7: Scenario 2
+
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 36]
+
+Internet-Draft                 YANG Semver                    March 2026
+
 
    For each revision N, P and Q, the following are possible YANG Semver
    versions when the revision is backwards comptible (BC) or non
@@ -2010,13 +2031,6 @@ Internet-Draft                 YANG Semver                    March 2026
    or NBC version off of 2.2.0.  One approach to avoid this situation is
    to avoid only incrementing the PATCH digit in the main branch (i.e.,
    increment at least the MINOR digit).
-
-
-
-Clarke, et al.          Expires 25 September 2026              [Page 36]
-
-Internet-Draft                 YANG Semver                    March 2026
-
 
    For revision Q -- given that it is at the head of the branch -- the
    following are possible YANG Semver versions when the revision is
@@ -2052,6 +2066,14 @@ Authors' Addresses
    1117 Budapest
    Magyar Tudosok Korutja
    Hungary
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 37]
+
+Internet-Draft                 YANG Semver                    March 2026
+
+
    Phone: +36-70-330-7909
    Email: balazs.lengyel@ericsson.com
 
@@ -2069,4 +2091,38 @@ Authors' Addresses
 
 
 
-Clarke, et al.          Expires 25 September 2026              [Page 37]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Clarke, et al.           Expires 2 October 2026                [Page 38]

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -6,14 +6,14 @@ Network Working Group                                     J. Clarke, Ed.
 Internet-Draft                                            R. Wilton, Ed.
 Updates: 9907, 8525, 7950 (if approved)              Cisco Systems, Inc.
 Intended status: Standards Track                               R. Rahman
-Expires: 2 October 2026                                          Equinix
+Expires: 15 October 2026                                         Equinix
                                                               B. Lengyel
                                                                 Ericsson
                                                                J. Sterne
                                                                    Nokia
                                                                B. Claise
                                                           Everything OPS
-                                                           31 March 2026
+                                                           13 April 2026
 
 
                         YANG Semantic Versioning
@@ -44,7 +44,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 2 October 2026.
+   This Internet-Draft will expire on 15 October 2026.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Clarke, et al.           Expires 2 October 2026                 [Page 1]
+Clarke, et al.           Expires 15 October 2026                [Page 1]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -71,9 +71,8 @@ Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
      1.1.  Updates to Other RFCs . . . . . . . . . . . . . . . . . .   3
-     1.2.  Editorial Note (To be removed by RFC Editor)  . . . . . .   4
    2.  Examples of How Versioning Is Applied To YANG Module
-           Revisions . . . . . . . . . . . . . . . . . . . . . . . .   4
+           Revisions . . . . . . . . . . . . . . . . . . . . . . . .   3
    3.  Terminology and Conventions . . . . . . . . . . . . . . . . .   5
    4.  YANG Semantic Versioning  . . . . . . . . . . . . . . . . . .   5
      4.1.  Relationship Between SemVer and YANG Semver . . . . . . .   5
@@ -105,17 +104,16 @@ Table of Contents
    11. Security Considerations . . . . . . . . . . . . . . . . . . .  29
    12. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  29
      12.1.  YANG Module Registrations  . . . . . . . . . . . . . . .  29
-
-
-
-
-Clarke, et al.           Expires 2 October 2026                 [Page 2]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
      12.2.  Guidance for YANG Semver in IANA maintained YANG modules
             and submodules . . . . . . . . . . . . . . . . . . . . .  30
+
+
+
+Clarke, et al.           Expires 15 October 2026                [Page 2]
+
+Internet-Draft                 YANG Semver                    April 2026
+
+
    13. References  . . . . . . . . . . . . . . . . . . . . . . . . .  31
      13.1.  Normative References . . . . . . . . . . . . . . . . . .  31
      13.2.  Informative References . . . . . . . . . . . . . . . . .  32
@@ -134,17 +132,18 @@ Internet-Draft                 YANG Semver                    March 2026
 
    This document defines a YANG extension that tags a YANG artifact
    (i.e., YANG modules, YANG submodules, and YANG packages
-   [I-D.ietf-netmod-yang-packages] ) with a version identifier that
-   adheres to extended semantic versioning rules [SemVer].  The goal
-   being to add a human readable version identifier that provides
-   compatibility information for the YANG artifact without needing to
-   compare or parse its body.  The version identifier and rules defined
-   herein represent the recommended approach to apply versioning to IETF
-   YANG artifacts.  This document defines augmentations to ietf-yang-
-   library to reflect the version of YANG modules within the module-set
-   data.  YANG Semver extends SemVer with an optional '_COMPAT' suffix
-   to support limited branching within YANG artifact revision histories,
-   as described in Section 4.3 and Section 4.4.3.
+   [I-D.ietf-netmod-yang-packages] ) with a version identifier (YANG
+   Semver) that adheres to extended semantic versioning rules [SemVer].
+   The goal being to add a human readable version identifier that
+   provides compatibility information for the YANG artifact without
+   needing to compare or parse its body.  The version identifier and
+   rules defined herein represent the recommended approach to apply
+   versioning to IETF YANG artifacts.  This document defines
+   augmentations to ietf-yang-library to reflect the version of YANG
+   modules within the module-set data.  YANG Semver extends SemVer with
+   an optional '_COMPAT' suffix to support limited branching within YANG
+   artifact revision histories, as described in Section 4.3 and
+   Section 4.4.3.
 
    Note that a specific revision of the SemVer 2.0.0 specification is
    referenced here (from June 19, 2020) to provide an immutable version.
@@ -159,28 +158,17 @@ Internet-Draft                 YANG Semver                    March 2026
    [RFC9907] to clarify how version statements are to be added to
    modules and submodules (Section 6).
 
-
-
-
-
-
-
-Clarke, et al.           Expires 2 October 2026                 [Page 3]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
-1.2.  Editorial Note (To be removed by RFC Editor)
-
-      Note to the RFC Editor: This section is to be removed prior to
-      publication.
-
-   This document updates [RFC9907].
-
 2.  Examples of How Versioning Is Applied To YANG Module Revisions
 
    The following diagram illustrates how the branched revision history
    and the YANG Semver version extension statement could be used:
+
+
+
+Clarke, et al.           Expires 15 October 2026                [Page 3]
+
+Internet-Draft                 YANG Semver                    April 2026
+
 
    Example YANG module with branched revision history.
 
@@ -219,18 +207,24 @@ Internet-Draft                 YANG Semver                    March 2026
                 |
             2022-09-30                 <- 3.0.0
 
-
-
-Clarke, et al.           Expires 2 October 2026                 [Page 4]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
                                   Figure 2
 
    Note that when no branching occurs, YANG Semver identifiers are
    equivalent to standard SemVer version numbers and the '_COMPAT'
    modifier is not needed.
+
+
+
+
+
+
+
+
+
+Clarke, et al.           Expires 15 October 2026                [Page 4]
+
+Internet-Draft                 YANG Semver                    April 2026
+
 
 3.  Terminology and Conventions
 
@@ -268,22 +262,25 @@ Internet-Draft                 YANG Semver                    March 2026
    semantic version number is legal according to the YANG Semver rules
    (though the inverse is not necessarily true).  YANG Semver is a
    superset of the SemVer rules, and allows for limited branching within
-   YANG artifacts.  If no branching occurs within a YANG artifact (i.e.,
-   you do not use the compatibility modifiers described below), the YANG
-   Semver version label will appear as a SemVer version number.  Note
+   YANG artifacts.  If no branching occurs within a YANG artifact (e.g.,
+   in IETF modules, which are not expected to use branching), the YANG
+   Semver version label will appear as a SemVer version number (i.e.,
+   they will not use the compatibility modifier described below).  Note
    that standard SemVer does not support branching and assumes a single
    linear progression of releases.  The optional '_COMPAT' modifier is
    unique to YANG Semver and is introduced to support the limited
-
-
-
-Clarke, et al.           Expires 2 October 2026                 [Page 5]
-
-Internet-Draft                 YANG Semver                    March 2026
-
-
    branching that may be needed for certain YANG artifact revision
    histories.
+
+
+
+
+
+
+Clarke, et al.           Expires 15 October 2026                [Page 5]
+
+Internet-Draft                 YANG Semver                    April 2026
+
 
 4.2.  YANG Semantic Version Extension
 
@@ -333,9 +330,12 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                 [Page 6]
+
+
+
+Clarke, et al.           Expires 15 October 2026                [Page 6]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
 4.4.  Semantic Versioning Scheme for YANG Artifacts
@@ -389,9 +389,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                 [Page 7]
+Clarke, et al.           Expires 15 October 2026                [Page 7]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
    *  'X' is the MAJOR version.  Changes in the MAJOR version number
@@ -445,9 +445,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                 [Page 8]
+Clarke, et al.           Expires 15 October 2026                [Page 8]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
    modifier MUST NOT change from "_non_compatible" to "_compatible" and
@@ -501,9 +501,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                 [Page 9]
+Clarke, et al.           Expires 15 October 2026                [Page 9]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
    Note that the meaning of a submodule may change drastically despite
@@ -557,9 +557,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 10]
+Clarke, et al.           Expires 15 October 2026               [Page 10]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
       2.0.0 - change existing model for performance reasons, e.g. re-key
@@ -613,9 +613,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 11]
+Clarke, et al.           Expires 15 October 2026               [Page 11]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
    Branching limitations should be carefully considered when doing
@@ -669,9 +669,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 12]
+Clarke, et al.           Expires 15 October 2026               [Page 12]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
        iii  "X.Y.Z_non_compatible" - the artifact version SHOULD be
@@ -725,9 +725,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 13]
+Clarke, et al.           Expires 15 October 2026               [Page 13]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
    [I-D.ietf-netmod-yang-module-versioning] defines the "rev:non-
@@ -781,9 +781,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 14]
+Clarke, et al.           Expires 15 October 2026               [Page 14]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
        revision 2017-02-07 {
@@ -837,9 +837,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 15]
+Clarke, et al.           Expires 15 October 2026               [Page 15]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
            description
@@ -893,9 +893,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 16]
+Clarke, et al.           Expires 15 October 2026               [Page 16]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
 5.1.  The recommended-min-version Extension
@@ -949,9 +949,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 17]
+Clarke, et al.           Expires 15 October 2026               [Page 17]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
       3.1.1_compatible (by condition 2 above, noting that modifiers are
@@ -1005,9 +1005,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 18]
+Clarke, et al.           Expires 15 October 2026               [Page 18]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
       1.0.0-202007.rc
@@ -1061,9 +1061,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 19]
+Clarke, et al.           Expires 15 October 2026               [Page 19]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
 6.1.1.  YANG Semver in New IETF Modules
@@ -1117,9 +1117,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 20]
+Clarke, et al.           Expires 15 October 2026               [Page 20]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
    extra metadata described below.  The YANG Semver in subsequent drafts
@@ -1173,9 +1173,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 21]
+Clarke, et al.           Expires 15 October 2026               [Page 21]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
 7.  Updates to ietf-yang-library
@@ -1229,9 +1229,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 22]
+Clarke, et al.           Expires 15 October 2026               [Page 22]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
        "IETF NETMOD (Network Modeling) Working Group";
@@ -1285,9 +1285,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 23]
+Clarke, et al.           Expires 15 October 2026               [Page 23]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
        description
@@ -1341,9 +1341,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 24]
+Clarke, et al.           Expires 15 October 2026               [Page 24]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
           statements per parent statement are allowed.  No
@@ -1397,9 +1397,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 25]
+Clarke, et al.           Expires 15 October 2026               [Page 25]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
    <CODE BEGINS> file "ietf-yang-library-semver@2025-09-29.yang"
@@ -1453,9 +1453,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 26]
+Clarke, et al.           Expires 15 October 2026               [Page 26]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
         This version of this YANG module is part of RFC XXXX; see
@@ -1509,9 +1509,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 27]
+Clarke, et al.           Expires 15 October 2026               [Page 27]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
      augment "/yanglib:yang-library/yanglib:module-set/yanglib:module/"
@@ -1565,9 +1565,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 28]
+Clarke, et al.           Expires 15 October 2026               [Page 28]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
    The initial revision of this document was refactored and built upon
@@ -1621,9 +1621,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 29]
+Clarke, et al.           Expires 15 October 2026               [Page 29]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
       URI: urn:ietf:params:xml:ns:yang:ietf-yang-library-semver
@@ -1677,9 +1677,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 30]
+Clarke, et al.           Expires 15 October 2026               [Page 30]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
    In addition to following the rules specified in the IANA
@@ -1733,9 +1733,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 31]
+Clarke, et al.           Expires 15 October 2026               [Page 31]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
    [RFC7950]  Bjorklund, M., Ed., "The YANG 1.1 Data Modeling Language",
@@ -1789,14 +1789,14 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 32]
+Clarke, et al.           Expires 15 October 2026               [Page 32]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
-              netmod-yang-schema-comparison-05, 20 October 2025,
+              netmod-yang-schema-comparison-06, 15 February 2026,
               <https://datatracker.ietf.org/doc/html/draft-ietf-netmod-
-              yang-schema-comparison-05>.
+              yang-schema-comparison-06>.
 
    [RFC4252]  Ylonen, T. and C. Lonvick, Ed., "The Secure Shell (SSH)
               Authentication Protocol", RFC 4252, DOI 10.17487/RFC4252,
@@ -1845,9 +1845,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 33]
+Clarke, et al.           Expires 15 October 2026               [Page 33]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
    [SemVer]   "Semantic Versioning 2.0.0 (text from June 19, 2020)",
@@ -1901,9 +1901,9 @@ Appendix A.  Example IETF Module Development
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 34]
+Clarke, et al.           Expires 15 October 2026               [Page 34]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
    A time later, the module needs to be revised to add additional
@@ -1957,9 +1957,9 @@ Appendix B.  Examples of _COMPAT Modifier Use
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 35]
+Clarke, et al.           Expires 15 October 2026               [Page 35]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
    It is also useful to consider the leftmost sequence (diagonal column)
@@ -2013,9 +2013,9 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 36]
+Clarke, et al.           Expires 15 October 2026               [Page 36]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
    For each revision N, P and Q, the following are possible YANG Semver
@@ -2069,9 +2069,9 @@ Authors' Addresses
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 37]
+Clarke, et al.           Expires 15 October 2026               [Page 37]
 
-Internet-Draft                 YANG Semver                    March 2026
+Internet-Draft                 YANG Semver                    April 2026
 
 
    Phone: +36-70-330-7909
@@ -2125,4 +2125,4 @@ Internet-Draft                 YANG Semver                    March 2026
 
 
 
-Clarke, et al.           Expires 2 October 2026                [Page 38]
+Clarke, et al.           Expires 15 October 2026               [Page 38]

--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -17,7 +17,7 @@ Expires: 15 October 2026                                         Equinix
 
 
                         YANG Semantic Versioning
-                    draft-ietf-netmod-yang-semver-24
+                    draft-ietf-netmod-yang-semver-25
 
 Abstract
 

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -82,7 +82,7 @@ document defines a YANG extension for controlling module imports based on these 
    revision suggestion to help document inter-module dependencies.</t>
 <t>This document defines a YANG extension that tags a YANG artifact (i.e., YANG modules, YANG submodules, and YANG packages <xref target="I-D.ietf-netmod-yang-packages" format="default"/>
 )
-        with a version identifier that adheres to extended semantic versioning rules <xref target="SemVer" format="default"/>.
+        with a version identifier (YANG Semver) that adheres to extended semantic versioning rules <xref target="SemVer" format="default"/>.
       The goal being to add a human readable version identifier that
     provides compatibility information for the YANG artifact without needing to compare or parse its body.
 The version identifier and rules defined herein represent the recommended approach to apply versioning to IETF YANG artifacts.
@@ -97,15 +97,6 @@ YANG Semver extends SemVer with an optional '_COMPAT' suffix to support limited 
   It updates <xref target="RFC8525" format="default"/> by adding a version leaf to modules and submodules (<xref target="ietf_yang_library_updates"/>).  It updates
   <xref target="RFC9907" format="default"/> to clarify how version statements are to be added to modules and submodules
   (<xref target="guidelines"/>).</t>
-  </section>
-  <section anchor="editor_note" numbered="true" toc="default">
-  <name>Editorial Note (To be removed by RFC Editor)</name>
-  <ul empty="true">
-          <li>
-            <t>Note to the RFC Editor: This section is to be removed prior to publication.</t>
-          </li>
-        </ul>
-  <t>This document updates <xref target="RFC9907" format="default"/>.</t>
   </section>
 </section>
 <section anchor="example_version_tree" title="Examples of How Versioning Is Applied To YANG Module Revisions">
@@ -179,8 +170,8 @@ YANG Semver extends SemVer with an optional '_COMPAT' suffix to support limited 
       <xref target="SemVer" format="default"/>
  is completely compatible with YANG Semver in that a SemVer semantic version number is legal according to the YANG Semver
 rules (though the inverse is not necessarily true).  YANG Semver is a superset of the SemVer rules, and allows for limited branching within YANG artifacts.  If no branching occurs within a YANG artifact
-    (i.e., you do not use the compatibility modifiers described below), the YANG Semver
-    version label will appear as a SemVer version number.
+    (e.g., in IETF modules, which are not expected to use branching), the YANG Semver
+    version label will appear as a SemVer version number (i.e., they will not use the compatibility modifier described below).
     Note that standard SemVer does not support branching and assumes a single linear progression of releases.
     The optional '_COMPAT' modifier is unique to YANG Semver and is introduced to support the limited branching that may be needed for certain YANG artifact revision histories.</t>
   </section>

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" updates="9907,8525,7950" category="std" ipr="trust200902" consensus="true" docName="draft-ietf-netmod-yang-semver-24" xml:lang="en" obsoletes="" submissionType="IETF" version="3">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" updates="9907,8525,7950" category="std" ipr="trust200902" consensus="true" docName="draft-ietf-netmod-yang-semver-25" xml:lang="en" obsoletes="" submissionType="IETF" version="3">
   <front>
     <title abbrev="YANG Semver">YANG Semantic Versioning</title>
-<seriesInfo name="Internet-Draft" value="draft-ietf-netmod-yang-semver-24"/>
+<seriesInfo name="Internet-Draft" value="draft-ietf-netmod-yang-semver-25"/>
 
     <author initials="J." surname="Clarke" fullname="Joe Clarke" role="editor">
       <organization>Cisco Systems, Inc.</organization>

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -719,8 +719,7 @@ The "_compatible" and "_non_compatible" modifiers as well as any metadata are ig
 <name>YANG Semver in IETF Modules</name>
 <t>All published IETF modules and submodules MUST use YANG semantic versions in their revisions.  This
 is an update to the guidance provided in <xref section="4.8" sectionFormat="of" target="RFC9907"/>.
-As IETF modules are not expected to require branching in their revision history, the '_COMPAT' modifier SHOULD NOT be used in IETF published modules.
-For more detailed guidance on YANG Semver for IANA maintained YANG modules and submodules, see <xref target="I-D.ietf-netmod-iana-yang-guidance"/>.</t>
+As IETF modules are not expected to require branching in their revision history, the '_COMPAT' modifier SHOULD NOT be used in IETF published modules.</t>
 <section anchor="ietf_new_module_development" numbered="true" toc="default">
 <name>YANG Semver in New IETF Modules</name>
 <t>Development of a new module or submodule (i.e., when there is no existing module of the same name) within the IETF MUST 
@@ -1216,6 +1215,7 @@ group <xref target="RFC3688"/>:</t>
     incremented if non-backwards-compatible changes are made.</t>
 <t>Because IANA versions YANG modules with a linear history, these modules
   will not need to use the "_compatible" or "_non_compatible" modifiers with the "Z_COMPAT" version element.</t>
+<t>See <xref target="I-D.ietf-netmod-iana-yang-guidance"/> for complete guidance on how to handle versioning for IANA maintained YANG modules.</t>
 </section>
 </section>
 </middle>

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" updates="8407,8525,7950" category="std" ipr="trust200902" consensus="true" docName="draft-ietf-netmod-yang-semver-24" xml:lang="en" obsoletes="" submissionType="IETF" version="3">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" updates="9907,8525,7950" category="std" ipr="trust200902" consensus="true" docName="draft-ietf-netmod-yang-semver-24" xml:lang="en" obsoletes="" submissionType="IETF" version="3">
   <front>
     <title abbrev="YANG Semver">YANG Semantic Versioning</title>
 <seriesInfo name="Internet-Draft" value="draft-ietf-netmod-yang-semver-24"/>
@@ -66,7 +66,7 @@
 <t>This document specifies a YANG extension along with guidelines for applying an extended set of
     semantic versioning rules to revisions of YANG artifacts (e.g., modules and packages).  Additionally, this
 document defines a YANG extension for controlling module imports based on these modified semantic versioning rules.</t>
-<t>This document updates RFCs 7950, 8407bis, and 8525.</t>
+<t>This document updates RFCs 7950, 9907, and 8525.</t>
     </abstract>
   </front>
   <middle>
@@ -86,7 +86,8 @@ document defines a YANG extension for controlling module imports based on these 
       The goal being to add a human readable version identifier that
     provides compatibility information for the YANG artifact without needing to compare or parse its body.
 The version identifier and rules defined herein represent the recommended approach to apply versioning to IETF YANG artifacts.
-This document defines augmentations to ietf-yang-library to reflect the version of YANG modules within the module-set data.</t>
+This document defines augmentations to ietf-yang-library to reflect the version of YANG modules within the module-set data.
+YANG Semver extends SemVer with an optional '_COMPAT' suffix to support limited branching within YANG artifact revision histories, as described in <xref target="version_pattern"/> and <xref target="branching_limitations"/>.</t>
     <t>Note that a specific revision of the SemVer 2.0.0 specification is referenced here (from June 19, 2020) to provide an immutable version.  This is because
     the 2.0.0 version of the specification has changed over time without any change to the semantic version itself.</t>
   <section anchor="rfc_updates" numbered="true" toc="default">
@@ -94,7 +95,7 @@ This document defines augmentations to ietf-yang-library to reflect the version 
   <t>This document updates <xref target="RFC7950" format="default"/> to clarify how ambiguous module imports are resolved
   (<xref target="import_semver"/>).
   It updates <xref target="RFC8525" format="default"/> by adding a version leaf to modules and submodules (<xref target="ietf_yang_library_updates"/>).  It updates
-  <xref target="I-D.ietf-netmod-rfc8407bis" format="default"/> to clarify how version statements are to be added to modules and submodules
+  <xref target="RFC9907" format="default"/> to clarify how version statements are to be added to modules and submodules
   (<xref target="guidelines"/>).</t>
   </section>
   <section anchor="editor_note" numbered="true" toc="default">
@@ -104,8 +105,7 @@ This document defines augmentations to ietf-yang-library to reflect the version 
             <t>Note to the RFC Editor: This section is to be removed prior to publication.</t>
           </li>
         </ul>
-  <t>This document updates <xref target="I-D.ietf-netmod-rfc8407bis" format="default"/>.  The header metadata for this document should be updated
-  to the new RFC number when <xref target="I-D.ietf-netmod-rfc8407bis" format="default"/> is published.</t>
+  <t>This document updates <xref target="RFC9907" format="default"/>.</t>
   </section>
 </section>
 <section anchor="example_version_tree" title="Examples of How Versioning Is Applied To YANG Module Revisions">
@@ -123,12 +123,30 @@ This document defines augmentations to ietf-yang-library to reflect the version 
              |        \
              |       2019-04-01     &lt;- 2.1.0
              |           |
-	 2019-05-01      |          &lt;- 3.1.0
-	                 |
+         2019-05-01      |          &lt;- 3.1.0
+                         |
                      2019-06-01     &lt;- 2.2.0
     </artwork>
   </figure>
   <t>The tree diagram above illustrates how an example module's revision history might evolve, over time.</t>
+  <t>For IETF modules, branching does not occur, resulting in a simpler linear revision history.
+    The following diagram illustrates a typical IETF module revision history:</t>
+  <t keepWithNext="true">Example IETF YANG module with linear revision history.</t>
+  <figure>
+    <artwork>
+       Module revision date      Example version identifier
+         2019-01-01                 &lt;- 1.0.0
+             |
+         2019-07-01                 &lt;- 1.1.0
+             |
+         2020-03-01                 &lt;- 2.0.0
+             |
+         2021-02-15                 &lt;- 2.1.0
+             |
+         2022-09-30                 &lt;- 3.0.0
+    </artwork>
+  </figure>
+  <t>Note that when no branching occurs, YANG Semver identifiers are equivalent to standard SemVer version numbers and the '_COMPAT' modifier is not needed.</t>
 </section>
   <section anchor="terminology" numbered="true" toc="default">
     <name>Terminology and Conventions</name>
@@ -162,7 +180,9 @@ This document defines augmentations to ietf-yang-library to reflect the version 
  is completely compatible with YANG Semver in that a SemVer semantic version number is legal according to the YANG Semver
 rules (though the inverse is not necessarily true).  YANG Semver is a superset of the SemVer rules, and allows for limited branching within YANG artifacts.  If no branching occurs within a YANG artifact
     (i.e., you do not use the compatibility modifiers described below), the YANG Semver
-    version label will appear as a SemVer version number.</t>
+    version label will appear as a SemVer version number.
+    Note that standard SemVer does not support branching and assumes a single linear progression of releases.
+    The optional '_COMPAT' modifier is unique to YANG Semver and is introduced to support the limited branching that may be needed for certain YANG artifact revision histories.</t>
   </section>
   <section anchor="version_extension" numbered="true" toc="default">
 <name>YANG Semantic Version Extension</name>
@@ -652,7 +672,7 @@ The "_compatible" and "_non_compatible" modifiers as well as any metadata are ig
 <name>Guidelines for Using YANG Semver During Module Development</name>
 <t>This section and the IETF-specific sub-section below provide YANG Semver-specific
     guidelines to consider when developing new YANG modules.  As such this section
-    updates <xref section="4.8" sectionFormat="of" target="I-D.ietf-netmod-rfc8407bis"/>.</t>
+    updates <xref section="4.8" sectionFormat="of" target="RFC9907"/>.</t>
 <t>All modules and submodules being developed or updated that use the YANG Semver
   versioning scheme MUST have unique YANG Semver version identifiers throughout their lifecycle.</t>
 <t>Development of a new YANG module or submodule outside of the IETF that uses the YANG Semver 
@@ -707,7 +727,9 @@ The "_compatible" and "_non_compatible" modifiers as well as any metadata are ig
 <section anchor="ietf_guidelines" numbered="true" toc="default">
 <name>YANG Semver in IETF Modules</name>
 <t>All published IETF modules and submodules MUST use YANG semantic versions in their revisions.  This
-is an update to the guidance provided in <xref section="4.8" sectionFormat="of" target="I-D.ietf-netmod-rfc8407bis"/>.</t>
+is an update to the guidance provided in <xref section="4.8" sectionFormat="of" target="RFC9907"/>.
+As IETF modules are not expected to require branching in their revision history, the '_COMPAT' modifier SHOULD NOT be used in IETF published modules.
+For more detailed guidance on YANG Semver for IANA maintained YANG modules and submodules, see <xref target="I-D.ietf-netmod-iana-yang-guidance"/>.</t>
 <section anchor="ietf_new_module_development" numbered="true" toc="default">
 <name>YANG Semver in New IETF Modules</name>
 <t>Development of a new module or submodule (i.e., when there is no existing module of the same name) within the IETF MUST 
@@ -1120,7 +1142,7 @@ document readability.</t>
 <section anchor="security" numbered="true" toc="default">
 <name>Security Considerations</name>
 <t>This section is modeled after the template described in Section 3.7
-of <xref target="I-D.ietf-netmod-rfc8407bis" format="default"/>.
+of <xref target="RFC9907" format="default"/>.
 </t>
 <t>The "ietf-yang-semver" and "ietf-yang-library-semver" YANG modules define data models
 that are designed to be accessed via YANG-based management protocols, such
@@ -1218,11 +1240,12 @@ group <xref target="RFC3688"/>:</t>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7950.xml"/>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8525.xml"/>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-netmod-yang-module-versioning.xml"/>
-<xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-netmod-rfc8407bis.xml"/>
+<xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.9907.xml"/>
 </references>
 <references>
 <name>Informative References</name>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.clacla-netmod-yang-model-update.xml"/>
+<xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-netmod-iana-yang-guidance.xml"/>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-netmod-yang-packages.xml"/>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-netmod-yang-schema-comparison.xml"/>
 <xi:include href="http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4252.xml"/>


### PR DESCRIPTION
- add something in intro about adding a suffix to semver
- add clarification in 4.1 that Semver doesn't support branching
- adjust example in 4.1 to be an IETF module (when no branching occurs)
- add a sentence in 6.1 to indicate COMPAT isn't intended to be used in IETF modules (SHOULD NOT)
- add a reference to IANA guidance (for more detailed guidance, xxx is available)
- while here, move rfc8607bis to 9907