### PR TITLE
Add a paragraph on why recommended-min0version allows NBC.

### DIFF
--- a/yang-semver/draft-ietf-netmod-yang-semver.txt
+++ b/yang-semver/draft-ietf-netmod-yang-semver.txt
@@ -6,14 +6,14 @@ Network Working Group                                     J. Clarke, Ed.
 Internet-Draft                                            R. Wilton, Ed.
 Updates: 9907, 8525, 7950 (if approved)              Cisco Systems, Inc.
 Intended status: Standards Track                               R. Rahman
-Expires: 16 October 2026                                         Equinix
+Expires: 6 November 2026                                         Equinix
                                                               B. Lengyel
                                                                 Ericsson
                                                                J. Sterne
                                                                    Nokia
                                                                B. Claise
                                                           Everything OPS
-                                                           14 April 2026
+                                                              5 May 2026
 
 
                         YANG Semantic Versioning
@@ -44,7 +44,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 16 October 2026.
+   This Internet-Draft will expire on 6 November 2026.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Clarke, et al.           Expires 16 October 2026                [Page 1]
+Clarke, et al.           Expires 6 November 2026                [Page 1]
 
-Internet-Draft                 YANG Semver                    April 2026
+Internet-Draft                 YANG Semver                      May 2026
 
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -90,36 +90,36 @@ Table of Contents
      5.1.  The recommended-min-version Extension . . . . . . . . . .  17
      5.2.  Import by YANG Semantic Version Rules . . . . . . . . . .  17
    6.  Guidelines for Using YANG Semver During Module Development  .  18
-     6.1.  YANG Semver in IETF Modules . . . . . . . . . . . . . . .  19
+     6.1.  YANG Semver in IETF Modules . . . . . . . . . . . . . . .  20
        6.1.1.  YANG Semver in New IETF Modules . . . . . . . . . . .  20
        6.1.2.  YANG Semver when updating IETF Modules  . . . . . . .  20
        6.1.3.  YANG Semver when there are multiple parallel competing
-               IETF drafts . . . . . . . . . . . . . . . . . . . . .  20
+               IETF drafts . . . . . . . . . . . . . . . . . . . . .  21
    7.  Updates to ietf-yang-library  . . . . . . . . . . . . . . . .  22
      7.1.  YANG library versioning augmentations . . . . . . . . . .  22
-       7.1.1.  Advertising version . . . . . . . . . . . . . . . . .  22
-   8.  YANG Modules  . . . . . . . . . . . . . . . . . . . . . . . .  22
+       7.1.1.  Advertising version . . . . . . . . . . . . . . . . .  23
+   8.  YANG Modules  . . . . . . . . . . . . . . . . . . . . . . . .  23
    9.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  28
-   10. Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  28
+   10. Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  29
    11. Security Considerations . . . . . . . . . . . . . . . . . . .  29
-   12. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  29
-     12.1.  YANG Module Registrations  . . . . . . . . . . . . . . .  29
+   12. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  30
+     12.1.  YANG Module Registrations  . . . . . . . . . . . . . . .  30
      12.2.  Guidance for YANG Semver in IANA maintained YANG modules
-            and submodules . . . . . . . . . . . . . . . . . . . . .  30
+            and submodules . . . . . . . . . . . . . . . . . . . . .  31
 
 
 
-Clarke, et al.           Expires 16 October 2026                [Page 2]
+Clarke, et al.           Expires 6 November 2026                [Page 2]
 
-Internet-Draft                 YANG Semver                    April 2026
+Internet-Draft                 YANG Semver                      May 2026
 
 
    13. References  . . . . . . . . . . . . . . . . . . . . . . . . .  31
-     13.1.  Normative References . . . . . . . . . . . . . . . . . .  31
+     13.1.  Normative References . . . . . . . . . . . . . . . . . .  32
      13.2.  Informative References . . . . . . . . . . . . . . . . .  32
    Appendix A.  Example IETF Module Development  . . . . . . . . . .  34
-   Appendix B.  Examples of _COMPAT Modifier Use . . . . . . . . . .  35
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  37
+   Appendix B.  Examples of _COMPAT Modifier Use . . . . . . . . . .  36
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  38
 
 1.  Introduction
 
@@ -165,9 +165,9 @@ Internet-Draft                 YANG Semver                    April 2026
 
 
 
-Clarke, et al.           Expires 16 October 2026                [Page 3]
+Clarke, et al.           Expires 6 November 2026                [Page 3]
 
-Internet-Draft                 YANG Semver                    April 2026
+Internet-Draft                 YANG Semver                      May 2026
 
 
    Example YANG module with branched revision history.
@@ -221,9 +221,9 @@ Internet-Draft                 YANG Semver                    April 2026
 
 
 
-Clarke, et al.           Expires 16 October 2026                [Page 4]
+Clarke, et al.           Expires 6 November 2026                [Page 4]
 
-Internet-Draft                 YANG Semver                    April 2026
+Internet-Draft                 YANG Semver                      May 2026
 
 
 3.  Terminology and Conventions
@@ -277,9 +277,9 @@ Internet-Draft                 YANG Semver                    April 2026
 
 
 
-Clarke, et al.           Expires 16 October 2026                [Page 5]
+Clarke, et al.           Expires 6 November 2026                [Page 5]
 
-Internet-Draft                 YANG Semver                    April 2026
+Internet-Draft                 YANG Semver                      May 2026
 
 
 4.2.  YANG Semantic Version Extension
@@ -333,9 +333,9 @@ Internet-Draft                 YANG Semver                    April 2026
 
 
 
-Clarke, et al.           Expires 16 October 2026                [Page 6]
+Clarke, et al.           Expires 6 November 2026                [Page 6]
 
-Internet-Draft                 YANG Semver                    April 2026
+Internet-Draft                 YANG Semver                      May 2026
 
 
 4.4.  Semantic Versioning Scheme for YANG Artifacts
@@ -389,9 +389,9 @@ Internet-Draft                 YANG Semver                    April 2026
 
 
 
-Clarke, et al.           Expires 16 October 2026                [Page 7]
+Clarke, et al.           Expires 6 November 2026                [Page 7]
 
-Internet-Draft                 YANG Semver                    April 2026
+Internet-Draft                 YANG Semver                      May 2026
 
 
    *  'X' is the MAJOR version.  Changes in the MAJOR version number
@@ -445,9 +445,9 @@ Internet-Draft                 YANG Semver                    April 2026
 
 
 
-Clarke, et al.           Expires 16 October 2026                [Page 8]
+Clarke, et al.           Expires 6 November 2026                [Page 8]
 
-Internet-Draft                 YANG Semver                    April 2026
+Internet-Draft                 YANG Semver                      May 2026
 
 
    modifier MUST NOT change from "_non_compatible" to "_compatible" and
@@ -501,9 +501,9 @@ Internet-Draft                 YANG Semver                    April 2026
 
 
 
-Clarke, et al.           Expires 16 October 2026                [Page 9]
+Clarke, et al.           Expires 6 November 2026                [Page 9]
 
-Internet-Draft                 YANG Semver                    April 2026
+Internet-Draft                 YANG Semver                      May 2026
 
 
    Note that the meaning of a submodule may change drastically despite
@@ -557,9 +557,9 @@ Internet-Draft                 YANG Semver                    April 2026
 
 
 
-Clarke, et al.           Expires 16 October 2026               [Page 10]
+Clarke, et al.           Expires 6 November 2026               [Page 10]
 
-Internet-Draft                 YANG Semver                    April 2026
+Internet-Draft                 YANG Semver                      May 2026
 
 
       2.0.0 - change existing model for performance reasons, e.g. re-key
@@ -613,9 +613,9 @@ Internet-Draft                 YANG Semver                    April 2026
 
 
 
-Clarke, et al.           Expires 16 October 2026               [Page 11]
+Clarke, et al.           Expires 6 November 2026               [Page 11]
 
-Internet-Draft                 YANG Semver                    April 2026
+Internet-Draft                 YANG Semver                      May 2026
 
 
    Branching limitations should be carefully considered when doing
@@ -669,9 +669,9 @@ Internet-Draft                 YANG Semver                    April 2026
 
 
 
-Clarke, et al.           Expires 16 October 2026               [Page 12]
+Clarke, et al.           Expires 6 November 2026               [Page 12]
 
-Internet-Draft                 YANG Semver                    April 2026
+Internet-Draft                 YANG Semver                      May 2026
 
 
        iii  "X.Y.Z_non_compatible" - the artifact version SHOULD be
@@ -725,9 +725,9 @@ Internet-Draft                 YANG Semver                    April 2026
 
 
 
-Clarke, et al.           Expires 16 October 2026               [Page 13]
+Clarke, et al.           Expires 6 November 2026               [Page 13]
 
-Internet-Draft                 YANG Semver                    April 2026
+Internet-Draft                 YANG Semver                      May 2026
 
 
    [I-D.ietf-netmod-yang-module-versioning] defines the "rev:non-
@@ -781,9 +781,9 @@ Internet-Draft                 YANG Semver                    April 2026
 
 
 
-Clarke, et al.           Expires 16 October 2026               [Page 14]
+Clarke, et al.           Expires 6 November 2026               [Page 14]
 
-Internet-Draft                 YANG Semver                    April 2026
+Internet-Draft                 YANG Semver                      May 2026
 
 
        revision 2017-02-07 {
@@ -837,9 +837,9 @@ Internet-Draft                 YANG Semver                    April 2026
 
 
 
-Clarke, et al.           Expires 16 October 2026               [Page 15]
+Clarke, et al.           Expires 6 November 2026               [Page 15]
 
-Internet-Draft                 YANG Semver                    April 2026
+Internet-Draft                 YANG Semver                      May 2026
 
 
            description
@@ -893,9 +893,9 @@ Internet-Draft                 YANG Semver                    April 2026
 
 
 
-Clarke, et al.           Expires 16 October 2026               [Page 16]
+Clarke, et al.           Expires 6 November 2026               [Page 16]
 
-Internet-Draft                 YANG Semver                    April 2026
+Internet-Draft                 YANG Semver                      May 2026
 
 
 5.1.  The recommended-min-version Extension
@@ -949,9 +949,9 @@ Internet-Draft                 YANG Semver                    April 2026
 
 
 
-Clarke, et al.           Expires 16 October 2026               [Page 17]
+Clarke, et al.           Expires 6 November 2026               [Page 17]
 
-Internet-Draft                 YANG Semver                    April 2026
+Internet-Draft                 YANG Semver                      May 2026
 
 
       3.1.1_compatible (by condition 2 above, noting that modifiers are
@@ -967,6 +967,16 @@ Internet-Draft                 YANG Semver                    April 2026
    cannot locate a module with a version that is viable according to the
    conditions above, that YANG compiler should emit a warning, and then
    continue to resolve the import based on established [RFC7950] rules.
+
+   Note that the rules above intentionally allow a version that
+   introduces non-backwards-compatible changes (i.e., a higher MAJOR
+   version, or a version carrying the "_non_compatible" modifier) to
+   satisfy the recommended-min-version.  This keeps the import
+   resolution rules simple, and reflects the fact that the
+   responsibility for ensuring a coherent set of module versions is
+   expected to be handled outside of this extension (e.g., by grouping
+   modules into YANG packages [I-D.ietf-netmod-yang-packages], which by
+   their nature describe a consistent set of module dependencies).
 
 6.  Guidelines for Using YANG Semver During Module Development
 
@@ -993,6 +1003,13 @@ Internet-Draft                 YANG Semver                    April 2026
    0.3.0 to 1.0.0-beta to indicate it is more mature and ready for
    testing).
 
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 18]
+
+Internet-Draft                 YANG Semver                      May 2026
+
+
    When using pre-release notation, the pre-release metadata MUST adhere
    to [SemVer] syntax.  The following are examples of valid pre-release
    versions:
@@ -1002,13 +1019,6 @@ Internet-Draft                 YANG Semver                    April 2026
       1.0.0-alpha.3
 
       1.0.0-beta.42
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 18]
-
-Internet-Draft                 YANG Semver                    April 2026
-
 
       1.0.0-202007.rc
 
@@ -1043,6 +1053,19 @@ Internet-Draft                 YANG Semver                    April 2026
    statement in a pre-released module or submodule that reflects its
    latest revision.
 
+
+
+
+
+
+
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 19]
+
+Internet-Draft                 YANG Semver                      May 2026
+
+
 6.1.  YANG Semver in IETF Modules
 
    All published IETF modules and submodules MUST use YANG semantic
@@ -1050,21 +1073,6 @@ Internet-Draft                 YANG Semver                    April 2026
    provided in Section 4.8 of [RFC9907].  As IETF modules are not
    expected to require branching in their revision history, the
    '_COMPAT' modifier SHOULD NOT be used in IETF published modules.
-
-
-
-
-
-
-
-
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 19]
-
-Internet-Draft                 YANG Semver                    April 2026
-
 
 6.1.1.  YANG Semver in New IETF Modules
 
@@ -1103,6 +1111,17 @@ Internet-Draft                 YANG Semver                    April 2026
    1.2.0 (since 1.0.0 would have been the initial, pre-NMDA release, and
    1.1.0 would have been the NMDA revision).
 
+
+
+
+
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 20]
+
+Internet-Draft                 YANG Semver                      May 2026
+
+
 6.1.3.  YANG Semver when there are multiple parallel competing IETF
         drafts
 
@@ -1114,14 +1133,6 @@ Internet-Draft                 YANG Semver                    April 2026
    The following recommendations apply to the 2nd, 3rd, etc. parallel
    drafts that develop a module or submodule with the same name.  The
    first draft published can simply use the guidelines above without any
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 20]
-
-Internet-Draft                 YANG Semver                    April 2026
-
-
    extra metadata described below.  The YANG Semver in subsequent drafts
    SHOULD include the full document name as a pre-release version
    identifier, including the current document revision.  For example, if
@@ -1148,6 +1159,25 @@ Internet-Draft                 YANG Semver                    April 2026
    2.  Using unique strings within the YANG Semver pre-release metadata
        (e.g. 2.0.0-johnsmith-02).
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 21]
+
+Internet-Draft                 YANG Semver                      May 2026
+
+
    Once an Internet Draft containing the module or submodule is adopted
    as an IETF document, the need for pre-release metadata changes.  In
    this context, the simplified X.Y.Z-REVISION notation is used, where
@@ -1168,15 +1198,6 @@ Internet-Draft                 YANG Semver                    April 2026
    the revision of the module changes.
 
    See Appendix A for a detailed example of IETF pre-release versions.
-
-
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 21]
-
-Internet-Draft                 YANG Semver                    April 2026
-
 
 7.  Updates to ietf-yang-library
 
@@ -1205,6 +1226,14 @@ Internet-Draft                 YANG Semver                    April 2026
                /yanglib:import-only-module/yanglib:submodule:
        +--ro version?   ysv:version
 
+
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 22]
+
+Internet-Draft                 YANG Semver                      May 2026
+
+
                                   Figure 4
 
 7.1.1.  Advertising version
@@ -1226,14 +1255,6 @@ Internet-Draft                 YANG Semver                    April 2026
      prefix ysv;
 
      organization
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 22]
-
-Internet-Draft                 YANG Semver                    April 2026
-
-
        "IETF NETMOD (Network Modeling) Working Group";
      contact
        "WG Web:   <http://datatracker.ietf.org/wg/netmod/>
@@ -1261,6 +1282,14 @@ Internet-Draft                 YANG Semver                    April 2026
         Redistribution and use in source and binary forms, with or
         without modification, is permitted pursuant to, and subject
         to the license terms contained in, the Revised BSD License
+
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 23]
+
+Internet-Draft                 YANG Semver                      May 2026
+
+
         set forth in Section 4.c of the IETF Trust's Legal Provisions
         Relating to IETF Documents
         (http://trustee.ietf.org/license-info).
@@ -1282,14 +1311,6 @@ Internet-Draft                 YANG Semver                    April 2026
 
      revision 2026-03-03 {
        ysv:version "0.25.0";
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 23]
-
-Internet-Draft                 YANG Semver                    April 2026
-
-
        description
          "Initial revision";
        reference
@@ -1317,6 +1338,14 @@ Internet-Draft                 YANG Semver                    April 2026
           Versions MUST be unique amongst all revisions of a
           module or submodule.
 
+
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 24]
+
+Internet-Draft                 YANG Semver                      May 2026
+
+
           Adding, changing or removing a version is a
           backwards-compatible change.";
        reference
@@ -1338,14 +1367,6 @@ Internet-Draft                 YANG Semver                    April 2026
 
           The statement MUST only be a substatement of the import
           statement.  Zero or one 'recommended-min-version'
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 24]
-
-Internet-Draft                 YANG Semver                    April 2026
-
-
           statements per parent statement are allowed.  No
           substatements for this extension have been
           standardized.
@@ -1374,6 +1395,13 @@ Internet-Draft                 YANG Semver                    April 2026
       * Typedefs
       */
 
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 25]
+
+Internet-Draft                 YANG Semver                      May 2026
+
+
      typedef version {
        type string {
          length "5..128";
@@ -1392,15 +1420,6 @@ Internet-Draft                 YANG Semver                    April 2026
 
    This YANG module contains the augmentations to the ietf-yang-library
    [RFC8525].
-
-
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 25]
-
-Internet-Draft                 YANG Semver                    April 2026
-
 
    <CODE BEGINS> file "ietf-yang-library-semver@2025-09-29.yang"
    module ietf-yang-library-semver {
@@ -1431,6 +1450,14 @@ Internet-Draft                 YANG Semver                    April 2026
                   <mailto:rwilton@cisco.com>
         Author:   Reshad Rahman
                   <mailto:reshad@yahoo.com>
+
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 26]
+
+Internet-Draft                 YANG Semver                      May 2026
+
+
         Author:   Balazs Lengyel
                   <mailto:balazs.lengyel@ericsson.com>
         Author:   Jason Sterne
@@ -1450,13 +1477,6 @@ Internet-Draft                 YANG Semver                    April 2026
         set forth in Section 4.c of the IETF Trust's Legal Provisions
         Relating to IETF Documents
         (http://trustee.ietf.org/license-info).
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 26]
-
-Internet-Draft                 YANG Semver                    April 2026
-
 
         This version of this YANG module is part of RFC XXXX; see
         the RFC itself for full legal notices.
@@ -1486,6 +1506,14 @@ Internet-Draft                 YANG Semver                    April 2026
        description
          "Grouping for module version information.";
        leaf version {
+
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 27]
+
+Internet-Draft                 YANG Semver                      May 2026
+
+
          type ysv:version;
          description
            "The version of the module or submodule.
@@ -1505,14 +1533,6 @@ Internet-Draft                 YANG Semver                    April 2026
          "Add a version to module information";
        uses module-version;
      }
-
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 27]
-
-Internet-Draft                 YANG Semver                    April 2026
-
 
      augment "/yanglib:yang-library/yanglib:module-set/yanglib:module/"
            + "yanglib:submodule" {
@@ -1541,6 +1561,15 @@ Internet-Draft                 YANG Semver                    April 2026
 
    The following people made substantial contributions to this document:
 
+
+
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 28]
+
+Internet-Draft                 YANG Semver                      May 2026
+
+
      Bo Wu
      lana.wubo@huawei.com
 
@@ -1559,16 +1588,6 @@ Internet-Draft                 YANG Semver                    April 2026
    Clarke, Juergen Schoenwaelder, Mahesh Jethanandani, Michael
    (Wangzitao), Per Andersson, Qin Wu, Reshad Rahman, Tom Hill, and Rob
    Wilton.
-
-
-
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 28]
-
-Internet-Draft                 YANG Semver                    April 2026
-
 
    The initial revision of this document was refactored and built upon
    [I-D.clacla-netmod-yang-model-update].  We would like to thank Kevin
@@ -1599,6 +1618,14 @@ Internet-Draft                 YANG Semver                    April 2026
    RESTCONF users to a preconfigured subset of all available NETCONF or
    RESTCONF protocol operations and content.
 
+
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 29]
+
+Internet-Draft                 YANG Semver                      May 2026
+
+
    The YANG modules define a set of identities, extensions, types, and
    groupings.  These nodes are intended to be reused by other YANG
    modules.  The module by itself does not expose any data nodes that
@@ -1618,13 +1645,6 @@ Internet-Draft                 YANG Semver                    April 2026
       Registrant Contact: The IESG.
 
       XML: N/A, the requested URI is an XML namespace.
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 29]
-
-Internet-Draft                 YANG Semver                    April 2026
-
 
       URI: urn:ietf:params:xml:ns:yang:ietf-yang-library-semver
 
@@ -1655,6 +1675,13 @@ Internet-Draft                 YANG Semver                    April 2026
       XML Namespace: urn:ietf:params:xml:ns:yang:ietf-yang-library-
       semver
 
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 30]
+
+Internet-Draft                 YANG Semver                      May 2026
+
+
       Prefix: yl-semver
 
       Maintained by IANA?  N
@@ -1671,16 +1698,6 @@ Internet-Draft                 YANG Semver                    April 2026
    IANA is responsible for maintaining and versioning all IANA (iana-)
    YANG modules and submodules, e.g., iana-if-types.yang [IfTypeYang]
    and iana-routing-types.yang [RoutingTypesYang].
-
-
-
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 30]
-
-Internet-Draft                 YANG Semver                    April 2026
-
 
    In addition to following the rules specified in the IANA
    Considerations section of [I-D.ietf-netmod-yang-module-versioning],
@@ -1713,6 +1730,14 @@ Internet-Draft                 YANG Semver                    April 2026
 
 13.  References
 
+
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 31]
+
+Internet-Draft                 YANG Semver                      May 2026
+
+
 13.1.  Normative References
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
@@ -1728,15 +1753,6 @@ Internet-Draft                 YANG Semver                    April 2026
               the Network Configuration Protocol (NETCONF)", RFC 6020,
               DOI 10.17487/RFC6020, October 2010,
               <https://www.rfc-editor.org/info/rfc6020>.
-
-
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 31]
-
-Internet-Draft                 YANG Semver                    April 2026
-
 
    [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
@@ -1766,6 +1782,18 @@ Internet-Draft                 YANG Semver                    April 2026
 
 13.2.  Informative References
 
+
+
+
+
+
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 32]
+
+Internet-Draft                 YANG Semver                      May 2026
+
+
    [I-D.clacla-netmod-yang-model-update]
               Claise, B., Clarke, J., Lengyel, B., and K. D'Souza, "New
               YANG Module Update Procedure", Work in Progress, Internet-
@@ -1786,13 +1814,6 @@ Internet-Draft                 YANG Semver                    April 2026
               netmod-yang-packages-06, 7 July 2025,
               <https://datatracker.ietf.org/doc/html/draft-ietf-netmod-
               yang-packages-06>.
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 32]
-
-Internet-Draft                 YANG Semver                    April 2026
-
 
    [I-D.ietf-netmod-yang-schema-comparison]
               Andersson, P., Wilton, R., and M. Vaško, "YANG Schema
@@ -1819,6 +1840,16 @@ Internet-Draft                 YANG Semver                    April 2026
               (NETCONF)", RFC 6241, DOI 10.17487/RFC6241, June 2011,
               <https://www.rfc-editor.org/info/rfc6241>.
 
+
+
+
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 33]
+
+Internet-Draft                 YANG Semver                      May 2026
+
+
    [RFC8040]  Bierman, A., Bjorklund, M., and K. Watsen, "RESTCONF
               Protocol", RFC 8040, DOI 10.17487/RFC8040, January 2017,
               <https://www.rfc-editor.org/info/rfc8040>.
@@ -1841,14 +1872,6 @@ Internet-Draft                 YANG Semver                    April 2026
               Multiplexed and Secure Transport", RFC 9000,
               DOI 10.17487/RFC9000, May 2021,
               <https://www.rfc-editor.org/info/rfc9000>.
-
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 33]
-
-Internet-Draft                 YANG Semver                    April 2026
-
 
    [openconfigsemver]
               "Semantic Versioning for Openconfig Models",
@@ -1876,6 +1899,13 @@ Appendix A.  Example IETF Module Development
    following represents the initial version tree (i.e., value of
    ysv:version) of the module as it's being initially developed.
 
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 34]
+
+Internet-Draft                 YANG Semver                      May 2026
+
+
    Version lineage for initial module development:
 
          0.1.0-draft-jdoe-netmod-example-module-00
@@ -1898,14 +1928,6 @@ Appendix A.  Example IETF Module Development
          |
        0.5.0
 
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 34]
-
-Internet-Draft                 YANG Semver                    April 2026
-
-
    At this point, the draft is standardized and becomes RFC12345 and the
    YANG module version becomes 1.0.0.
 
@@ -1927,6 +1949,18 @@ Internet-Draft                 YANG Semver                    April 2026
          1.1.0-draft-asmith-netmod-exmod-changes-00
            |
          1.1.0-draft-asmith-netmod-exmod-changes-01
+
+
+
+
+
+
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 35]
+
+Internet-Draft                 YANG Semver                      May 2026
+
 
    At this point, the WG decides to merge some aspects of both and adopt
    the work in asmith's draft as draft-ietf-netmod-exmod-changes.  Since
@@ -1951,17 +1985,6 @@ Appendix B.  Examples of _COMPAT Modifier Use
    YANG Semver of a YANG module.  While module development is considered
    here, this is appliacable to any YANG artifact.
 
-
-
-
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 35]
-
-Internet-Draft                 YANG Semver                    April 2026
-
-
    In the scenarios below, the X axis represents relative time (date &
    time) that a module is being published.  Module versions to the right
    are more recent than module versions to the left.  In scenario 1, for
@@ -1980,6 +2003,20 @@ Internet-Draft                 YANG Semver                    April 2026
    branch) and not expected to occur much in modules published by
    standard bodies (which tend to be linear and only update the head of
    the single branch).
+
+
+
+
+
+
+
+
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 36]
+
+Internet-Draft                 YANG Semver                      May 2026
+
 
            2.0.0-----A
              \
@@ -2002,21 +2039,6 @@ Internet-Draft                 YANG Semver                    April 2026
    2.2.0 is not allowed for A (see Section 4.4.3), and 4.0.0 is not
    recommended (likely to cause confusion since it does not have 3.0.0
    as an ancestor).
-
-
-
-
-
-
-
-
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 36]
-
-Internet-Draft                 YANG Semver                    April 2026
-
 
            2.0.0
              \
@@ -2045,6 +2067,13 @@ Internet-Draft                 YANG Semver                    April 2026
    to avoid only incrementing the PATCH digit in the main branch (i.e.,
    increment at least the MINOR digit).
 
+
+
+Clarke, et al.           Expires 6 November 2026               [Page 37]
+
+Internet-Draft                 YANG Semver                      May 2026
+
+
    For revision Q -- given that it is at the head of the branch -- the
    following are possible YANG Semver versions when the revision is
    backwards compatible (BC) or non backwards compatible (NBC):
@@ -2066,14 +2095,6 @@ Authors' Addresses
 
    Robert Wilton (editor)
    Cisco Systems, Inc.
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 37]
-
-Internet-Draft                 YANG Semver                    April 2026
-
-
    Email: rwilton@cisco.com
 
 
@@ -2104,25 +2125,4 @@ Internet-Draft                 YANG Semver                    April 2026
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Clarke, et al.           Expires 16 October 2026               [Page 38]
+Clarke, et al.           Expires 6 November 2026               [Page 38]

--- a/yang-semver/draft-ietf-netmod-yang-semver.xml
+++ b/yang-semver/draft-ietf-netmod-yang-semver.xml
@@ -657,6 +657,11 @@ The "_compatible" and "_non_compatible" modifiers as well as any metadata are ig
 </ul>
 <t>If a compiler that supports the recommended-min-version extension cannot locate a module with a version that is viable according to the conditions above, 
   that YANG compiler should emit a warning, and then continue to resolve the import based on established <xref target="RFC7950" format="default"/> rules.</t>
+<t>Note that the rules above intentionally allow a version that introduces non-backwards-compatible changes (i.e., a higher MAJOR version, or a version
+  carrying the "_non_compatible" modifier) to satisfy the recommended-min-version.  This keeps the import resolution rules simple, and reflects the
+  fact that the responsibility for ensuring a coherent set of module versions is expected to be handled outside of this extension (e.g., by
+  grouping modules into YANG packages <xref target="I-D.ietf-netmod-yang-packages" format="default"/>, which by their nature describe a consistent
+  set of module dependencies).</t>
 </section>
 </section>
 <section anchor="guidelines" numbered="true" toc="default">


### PR DESCRIPTION
This came up on one of our calls.  While it's clear an NBC version is allowed, there was nothing saying why it was allowed as that might intuitively seem contradictory to the spirit of SemVer.