### PR TITLE
minor fixes

### DIFF
--- a/yang-module-filename/draft-ietf-netmod-yang-module-filename.xml
+++ b/yang-module-filename/draft-ietf-netmod-yang-module-filename.xml
@@ -22,7 +22,7 @@
      ipr="trust200902">
 
   <front>
-    <title abbrev="YANG module file name convention">
+    <title abbrev="YANG Module File Name Convention">
         YANG module file name convention
     </title>
 
@@ -127,7 +127,7 @@
       </t>
 
       <t>
-        Even though the ysv:version and the file name MUST match, the
+        Even though the ysv:version and the file name must match, the
         authorative source for the ysv:version is the contents in the YANG
         module, not the file name.
       </t>
@@ -135,9 +135,9 @@
       <t>
         Note that several files might be created as a consequence of using
         ysv:version or revision-date. For instance a YANG module without
-        ysv:version can be defined in either module.yang,
-        module@2020-02-20.yang, or both. A YANG module with ysv:version can be
-        represented by module@1.0.0.yang, module@2026-06-02.yang, module.yang.
+        ysv:version can be defined in either "module.yang",
+        "module@2020-02-20.yang", or both. A YANG module with ysv:version can be
+        represented by "module@1.0.0.yang", "module@2026-06-02.yang", "module.yang".
         The contents of the YANG modules for the same revision MUST be identical
         byte-for-byte.
       </t>
@@ -258,14 +258,14 @@
       </t>
 
       <t>
-        The "YANG Module Names" Registry need to support YANG modules
+        The "YANG Module Names" registry under "YANG Parameters" registry group need to support YANG modules
         with both the existing file name convention and the file name
         convention defined in this document.
       </t>
 
       <t>
         The IANA action is to update the registry to support the YANG module
-        file name convention. If the YANG module (or submodule) has an
+        file name convention. If a YANG module (or submodule) has an
         associated YANG semantic version (ysv:version) a file name including it
         is listed. Additionally, a file name with revision-date is listed for
         the YANG module (or submodule). Files with the same revision are
@@ -274,7 +274,7 @@
     </section>
 
     <section anchor="security" title="Security Considerations">
-      <t>There are no security considerations for this draft.</t>
+      <t>There are no security considerations for this document.</t>
     </section>
   </middle>
   <back>


### PR DESCRIPTION
avoid duplicated normative language for the same behavior "The ysv:version in the file name MUST match the ysv:version" ...and some very minor edits